### PR TITLE
Handle the outputs logic, run monitoring in thread, and make record types configurable

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,7 +39,6 @@ jobs:
           # - 'pypy-3.8'
           # - 'pypy-3.9'
           # - 'pypy-3.10'
-        toxenv: [py]
         # exclude:
         #   # No older Pythons on arm64 macos-latest
         #   - python-version: '3.7'
@@ -77,24 +76,5 @@ jobs:
         run: pip install .
 
       - name: Run tests
-        # if: matrix.toxenv == 'py'
-        run: ./run-tests.sh
-        # run: ./run-tests.sh -e py -- -vv --ci --cov-report=xml
-        # env:
-          # GITHUB_TOKEN: ${{ secrets.GH_DOWNLOAD_TOKEN }}
-
-      # TODO
-      # - name: Run generic tests
-      #   if: matrix.toxenv != 'py'
-      #   run: tox -e ${{ matrix.toxenv }}
-      #
-      # TODO
-      # - name: Upload coverage to Codecov
-      #   if: matrix.toxenv == 'py'
-      #   uses: codecov/codecov-action@v4
-      #   with:
-      #     fail_ci_if_error: false
-      #     token: ${{ secrets.CODECOV_TOKEN }}
-      #     name: ${{ matrix.python-version }}
-
+        run: tox -e py
 # vim:set et sts=2:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,15 +30,14 @@ jobs:
           # - windows-latest
           - ubuntu-latest
         python-version:
-          # - '3.7'
-          # - '3.8'
-          # - '3.9'
-          # - '3.10'
+          - '3.8'
+          - '3.9'
+          - '3.10'
           - '3.11'
           - '3.12'
-          # - 'pypy-3.8'
-          # - 'pypy-3.9'
-          # - 'pypy-3.10'
+          - 'pypy-3.8'
+          - 'pypy-3.9'
+          - 'pypy-3.10'
         # exclude:
         #   # No older Pythons on arm64 macos-latest
         #   - python-version: '3.7'
@@ -77,4 +76,7 @@ jobs:
 
       - name: Run tests
         run: tox -e py
+
+      - name: Run smoke tests
+        run: ./smoke-tests.sh
 # vim:set et sts=2:

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ src/__pycache__/
 duct.egg-info/
 
 .duct/
+.idea

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,9 @@ classifiers =
     # Development Status :: 5 - Production/Stable
     Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
     Programming Language :: Python :: Implementation :: CPython
@@ -47,7 +50,7 @@ py_modules = duct
 package_dir =
     =src
 include_package_data = True
-python_requires = >= 3.11
+python_requires = >= 3.8
 
 [options.entry_points]
 console_scripts =

--- a/smoke-tests.sh
+++ b/smoke-tests.sh
@@ -1,3 +1,4 @@
+# Smoketests
 rm -rf .duct/*
 duct --report-interval 2 --sample-interval 0.5 ./test_script.py -- --duration 6 --cpu-load 50000 --memory-size 500
 find .duct/ -name '*.json' -exec sh -c 'echo "File: $1)"; cat "$1" | jq' _ {} \;

--- a/src/duct.py
+++ b/src/duct.py
@@ -71,7 +71,7 @@ class Report:
                     for gpu in gpu_info[1:]
                 ]
             except subprocess.CalledProcessError:
-                self.gpus = "Failed to query GPU info"
+                self.gpus = ["Failed to query GPU info"]
 
     def collect_sample(self):
         process_data = {}
@@ -125,7 +125,7 @@ class Report:
                 "Command": self.command,
                 "System": self.system_info,
                 "ENV": self.env,
-                "GPU": self.gpu,
+                "GPU": self.gpus,
             }
         )
 
@@ -257,7 +257,7 @@ class TeeStream:
 
     def close(self):
         """Close the slave fd and the file when done."""
-        os.close(self.listener_fd)
+        os.close(self.writer_fd)
         self.file.close()
 
 

--- a/src/duct.py
+++ b/src/duct.py
@@ -147,44 +147,52 @@ def create_and_parse_args():
     parser.add_argument("command", help="The command to execute.")
     parser.add_argument("arguments", nargs="*", help="Arguments for the command.")
     parser.add_argument(
-        "-p", "--output-prefix",
+        "-p",
+        "--output-prefix",
         type=str,
-        default=os.getenv("DUCT_OUTPUT_PREFIX", ".duct/logs/{datetime_filesafe}-{pid}_"),
+        default=os.getenv(
+            "DUCT_OUTPUT_PREFIX", ".duct/logs/{datetime_filesafe}-{pid}_"
+        ),
         help="File string format to be used as a prefix for the files -- the captured "
-             "stdout and stderr and the resource usage logs. The understood variables are "
-             "{datetime}, {datetime_filesafe}, and {pid}. "
-             "Leading directories will be created if they do not exist. "
-             "You can also provide value via DUCT_OUTPUT_PREFIX env variable. "
+        "stdout and stderr and the resource usage logs. The understood variables are "
+        "{datetime}, {datetime_filesafe}, and {pid}. "
+        "Leading directories will be created if they do not exist. "
+        "You can also provide value via DUCT_OUTPUT_PREFIX env variable. ",
     )
     parser.add_argument(
-        "--s-i", "--sample-interval",
+        "--sample-interval",
+        "--s-i",
         type=float,
         default=float(os.getenv("DUCT_SAMPLE_INTERVAL", "1.0")),
         help="Interval in seconds between status checks of the running process.",
     )
     parser.add_argument(
-        "--r-i", "--report-interval",
+        "--report-interval",
+        "--r-i",
         type=float,
         default=float(os.getenv("DUCT_REPORT_INTERVAL", "60.0")),
         help="Interval in seconds at which to report aggregated data.",
     )
     parser.add_argument(
-        "-c", "--capture-outputs",
+        "-c",
+        "--capture-outputs",
         type=str,
         default=os.getenv("DUCT_CAPTURE_OUTPUTS", "all"),
         choices=["all", "none", "stdout", "stderr"],
         help="Record stdout, stderr, all, or none to log files. "
-        "You can also provide value via DUCT_CAPTURE_OUTPUTS env variable."
+        "You can also provide value via DUCT_CAPTURE_OUTPUTS env variable.",
     )
     parser.add_argument(
-        "-o", "--outputs",
+        "-o",
+        "--outputs",
         type=str,
         default="all",
         choices=["all", "none", "stdout", "stderr"],
         help="Print stdout, stderr, all, or none to stdout/stderr respectively.",
     )
     parser.add_argument(
-        "-t", "--record-types",
+        "-t",
+        "--record-types",
         type=str,
         default="all",
         choices=["all", "system-summary", "processes-samples"],
@@ -255,7 +263,7 @@ def monitor_process(
             for pid, pinfo in aggregated.items():
                 with open(
                     resource_stats_log_path.format(
-                        output_prefix=output_prefix, sep=sep, pid=pid
+                        output_prefix=output_prefix, pid=pid
                     ),
                     "a",
                 ) as resource_statistics_log:

--- a/src/duct.py
+++ b/src/duct.py
@@ -261,21 +261,22 @@ def monitor_process(
 
 
 def prepare_outputs(capture_outputs, outputs, output_prefix):
+    sep = "" if output_prefix.endswith(os.sep) else "-"
     if capture_outputs in ["all", "stdout"] and outputs in ["all", "stdout"]:
-        stdout = TeeStream(f"{output_prefix}stdout")
+        stdout = TeeStream(f"{output_prefix}{sep}stdout")
         stdout.start()
     elif capture_outputs in ["all", "stdout"] and outputs in ["none", "stderr"]:
-        stdout = open(f"{output_prefix}stdout")
+        stdout = open(f"{output_prefix}{sep}stdout")
     elif capture_outputs in ["none", "stderr"] and outputs in ["all", "stdout"]:
         stdout = subprocess.PIPE
     else:
         stdout = subprocess.DEVNULL
 
     if capture_outputs in ["all", "stderr"] and outputs in ["all", "stderr"]:
-        stderr = TeeStream(f"{output_prefix}stderr")
+        stderr = TeeStream(f"{output_prefix}{sep}stderr")
         stderr.start()
     elif capture_outputs in ["all", "stderr"] and outputs in ["none", "stdout"]:
-        stderr = open(f"{output_prefix}/stderr")
+        stderr = open(f"{output_prefix}{sep}stderr")
     elif capture_outputs in ["none", "stdout"] and outputs in [
         "all",
         "stderr",

--- a/src/duct.py
+++ b/src/duct.py
@@ -153,7 +153,7 @@ def create_and_parse_args():
         help="Interval in seconds between status checks of the running process.",
     )
     parser.add_argument(
-        "--output_prefix",
+        "--output-prefix",
         type=str,
         default=os.getenv("DUCT_OUTPUT_PREFIX", f".duct/run-logs/{file_safe_iso}"),
         help="Directory in which all logs will be saved.",

--- a/src/duct.py
+++ b/src/duct.py
@@ -256,8 +256,7 @@ def monitor_process(
                     pinfo["elapsed_time"] = elapsed_time
                     resource_statistics_log.write(json.dumps(aggregated))
             report.number += 1
-
-    time.sleep(sample_interval)
+        time.sleep(sample_interval)
 
 
 def prepare_outputs(capture_outputs, outputs, output_prefix):

--- a/src/duct.py
+++ b/src/duct.py
@@ -239,9 +239,9 @@ def monitor_process(
 ):
     while True:
         if process.poll() is not None:  # the passthrough command has finished
-            if isinstance(stdout, TeeStream):
+            if hasattr(stdout, "close"):
                 stdout.close()
-            if isinstance(stderr, TeeStream):
+            if hasattr(stderr, "close"):
                 stderr.close()
             break
 
@@ -263,6 +263,8 @@ def prepare_outputs(capture_outputs, outputs, output_prefix):
     if capture_outputs in ["all", "stdout"] and outputs in ["all", "stdout"]:
         stdout = TeeStream(f"{output_prefix}/stdout.txt")
         stdout.start()
+    elif capture_outputs in ["all", "stdout"] and outputs in ["none", "stderr"]:
+        stdout = open(f"{output_prefix}/stdout.txt")
     elif capture_outputs in ["none", "stderr"] and outputs in ["all", "stdout"]:
         stdout = subprocess.PIPE
     else:
@@ -271,6 +273,8 @@ def prepare_outputs(capture_outputs, outputs, output_prefix):
     if capture_outputs in ["all", "stderr"] and outputs in ["all", "stderr"]:
         stderr = TeeStream(f"{output_prefix}/stderr.txt")
         stderr.start()
+    elif capture_outputs in ["all", "stderr"] and outputs in ["none", "stdout"]:
+        stderr = open(f"{output_prefix}/stderr.txt")
     elif capture_outputs in ["none", "stdout"] and outputs in [
         "all",
         "stderr",

--- a/test/test_prepare_outputs.py
+++ b/test/test_prepare_outputs.py
@@ -32,8 +32,8 @@ def test_prepare_outputs_all_none():
     with patch("builtins.open", new_callable=MagicMock) as mock_open:
         stdout, stderr = prepare_outputs("all", "none", output_prefix)
         calls = [
-            call(f"{output_prefix}stdout"),
-            call(f"{output_prefix}stderr"),
+            call(f"{output_prefix}stdout", "w"),
+            call(f"{output_prefix}stderr", "w"),
         ]
         mock_open.assert_has_calls(calls, any_order=True)
         assert stdout == mock_open.return_value

--- a/test/test_prepare_outputs.py
+++ b/test/test_prepare_outputs.py
@@ -10,7 +10,7 @@ def test_prepare_outputs_all_stdout():
     ) as mock_open:
         mock_tee_stream.return_value.start = MagicMock()
         stdout, stderr = prepare_outputs("all", "stdout", output_prefix)
-        mock_tee_stream.assert_called_with(f"{output_prefix}/stdout.txt")
+        mock_tee_stream.assert_called_with(f"{output_prefix}-stdout")
         assert stdout == mock_tee_stream.return_value
         assert stderr == mock_open.return_value
 
@@ -22,7 +22,7 @@ def test_prepare_outputs_all_stderr():
     ) as mock_open:
         mock_tee_stream.return_value.start = MagicMock()
         stdout, stderr = prepare_outputs("all", "stderr", output_prefix)
-        mock_tee_stream.assert_called_with(f"{output_prefix}/stderr.txt")
+        mock_tee_stream.assert_called_with(f"{output_prefix}-stderr")
         assert stdout == mock_open.return_value
         assert stderr == mock_tee_stream.return_value
 
@@ -32,8 +32,8 @@ def test_prepare_outputs_all_none():
     with patch("builtins.open", new_callable=MagicMock) as mock_open:
         stdout, stderr = prepare_outputs("all", "none", output_prefix)
         calls = [
-            call(f"{output_prefix}/stdout.txt"),
-            call(f"{output_prefix}/stderr.txt"),
+            call(f"{output_prefix}-stdout"),
+            call(f"{output_prefix}-stderr"),
         ]
         mock_open.assert_has_calls(calls, any_order=True)
         assert stdout == mock_open.return_value
@@ -62,7 +62,7 @@ def test_prepare_outputs_all_all():
         assert stdout == mock_tee_stream.return_value
         assert stderr == mock_tee_stream.return_value
         calls = [
-            call(f"{output_prefix}/stdout.txt"),
-            call(f"{output_prefix}/stderr.txt"),
+            call(f"{output_prefix}-stdout"),
+            call(f"{output_prefix}-stderr"),
         ]
         mock_tee_stream.assert_has_calls(calls, any_order=True)

--- a/test/test_prepare_outputs.py
+++ b/test/test_prepare_outputs.py
@@ -1,0 +1,68 @@
+import subprocess
+from unittest.mock import MagicMock, call, patch
+from duct import prepare_outputs
+
+
+def test_prepare_outputs_all_stdout():
+    output_prefix = "test_outputs"
+    with patch("duct.TeeStream") as mock_tee_stream, patch(
+        "builtins.open", new_callable=MagicMock
+    ) as mock_open:
+        mock_tee_stream.return_value.start = MagicMock()
+        stdout, stderr = prepare_outputs("all", "stdout", output_prefix)
+        mock_tee_stream.assert_called_with(f"{output_prefix}/stdout.txt")
+        assert stdout == mock_tee_stream.return_value
+        assert stderr == mock_open.return_value
+
+
+def test_prepare_outputs_all_stderr():
+    output_prefix = "test_outputs"
+    with patch("duct.TeeStream") as mock_tee_stream, patch(
+        "builtins.open", new_callable=MagicMock
+    ) as mock_open:
+        mock_tee_stream.return_value.start = MagicMock()
+        stdout, stderr = prepare_outputs("all", "stderr", output_prefix)
+        mock_tee_stream.assert_called_with(f"{output_prefix}/stderr.txt")
+        assert stdout == mock_open.return_value
+        assert stderr == mock_tee_stream.return_value
+
+
+def test_prepare_outputs_all_none():
+    output_prefix = "test_outputs"
+    with patch("builtins.open", new_callable=MagicMock) as mock_open:
+        stdout, stderr = prepare_outputs("all", "none", output_prefix)
+        calls = [
+            call(f"{output_prefix}/stdout.txt"),
+            call(f"{output_prefix}/stderr.txt"),
+        ]
+        mock_open.assert_has_calls(calls, any_order=True)
+        assert stdout == mock_open.return_value
+        assert stderr == mock_open.return_value
+
+
+def test_prepare_outputs_none_stdout():
+    output_prefix = "test_outputs"
+    stdout, stderr = prepare_outputs("none", "stdout", output_prefix)
+    assert stdout == subprocess.PIPE
+    assert stderr == subprocess.DEVNULL
+
+
+def test_prepare_outputs_none_stderr():
+    output_prefix = "test_outputs"
+    stdout, stderr = prepare_outputs("none", "stderr", output_prefix)
+    assert stderr == subprocess.PIPE
+    assert stdout == subprocess.DEVNULL
+
+
+def test_prepare_outputs_all_all():
+    output_prefix = "test_outputs"
+    with patch("duct.TeeStream") as mock_tee_stream:
+        mock_tee_stream.return_value.start = MagicMock()
+        stdout, stderr = prepare_outputs("all", "all", output_prefix)
+        assert stdout == mock_tee_stream.return_value
+        assert stderr == mock_tee_stream.return_value
+        calls = [
+            call(f"{output_prefix}/stdout.txt"),
+            call(f"{output_prefix}/stderr.txt"),
+        ]
+        mock_tee_stream.assert_has_calls(calls, any_order=True)

--- a/test/test_prepare_outputs.py
+++ b/test/test_prepare_outputs.py
@@ -4,36 +4,36 @@ from duct import prepare_outputs
 
 
 def test_prepare_outputs_all_stdout():
-    output_prefix = "test_outputs"
+    output_prefix = "test_outputs_"
     with patch("duct.TeeStream") as mock_tee_stream, patch(
         "builtins.open", new_callable=MagicMock
     ) as mock_open:
         mock_tee_stream.return_value.start = MagicMock()
         stdout, stderr = prepare_outputs("all", "stdout", output_prefix)
-        mock_tee_stream.assert_called_with(f"{output_prefix}-stdout")
+        mock_tee_stream.assert_called_with(f"{output_prefix}stdout")
         assert stdout == mock_tee_stream.return_value
         assert stderr == mock_open.return_value
 
 
 def test_prepare_outputs_all_stderr():
-    output_prefix = "test_outputs"
+    output_prefix = "test_outputs_"
     with patch("duct.TeeStream") as mock_tee_stream, patch(
         "builtins.open", new_callable=MagicMock
     ) as mock_open:
         mock_tee_stream.return_value.start = MagicMock()
         stdout, stderr = prepare_outputs("all", "stderr", output_prefix)
-        mock_tee_stream.assert_called_with(f"{output_prefix}-stderr")
+        mock_tee_stream.assert_called_with(f"{output_prefix}stderr")
         assert stdout == mock_open.return_value
         assert stderr == mock_tee_stream.return_value
 
 
 def test_prepare_outputs_all_none():
-    output_prefix = "test_outputs"
+    output_prefix = "test_outputs_"
     with patch("builtins.open", new_callable=MagicMock) as mock_open:
         stdout, stderr = prepare_outputs("all", "none", output_prefix)
         calls = [
-            call(f"{output_prefix}-stdout"),
-            call(f"{output_prefix}-stderr"),
+            call(f"{output_prefix}stdout"),
+            call(f"{output_prefix}stderr"),
         ]
         mock_open.assert_has_calls(calls, any_order=True)
         assert stdout == mock_open.return_value
@@ -41,28 +41,28 @@ def test_prepare_outputs_all_none():
 
 
 def test_prepare_outputs_none_stdout():
-    output_prefix = "test_outputs"
+    output_prefix = "test_outputs_"
     stdout, stderr = prepare_outputs("none", "stdout", output_prefix)
     assert stdout == subprocess.PIPE
     assert stderr == subprocess.DEVNULL
 
 
 def test_prepare_outputs_none_stderr():
-    output_prefix = "test_outputs"
+    output_prefix = "test_outputs_"
     stdout, stderr = prepare_outputs("none", "stderr", output_prefix)
     assert stderr == subprocess.PIPE
     assert stdout == subprocess.DEVNULL
 
 
 def test_prepare_outputs_all_all():
-    output_prefix = "test_outputs"
+    output_prefix = "test_outputs_"
     with patch("duct.TeeStream") as mock_tee_stream:
         mock_tee_stream.return_value.start = MagicMock()
         stdout, stderr = prepare_outputs("all", "all", output_prefix)
         assert stdout == mock_tee_stream.return_value
         assert stderr == mock_tee_stream.return_value
         calls = [
-            call(f"{output_prefix}-stdout"),
-            call(f"{output_prefix}-stderr"),
+            call(f"{output_prefix}stdout"),
+            call(f"{output_prefix}stderr"),
         ]
         mock_tee_stream.assert_has_calls(calls, any_order=True)

--- a/test_logs.py
+++ b/test_logs.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+import argparse
+import sys
+import time
+
+
+def consume_cpu(duration, _):
+    """Function to consume CPU proportional to 'load' for 'duration' seconds"""
+    for i in range(duration):
+        print(f"out: {i}")
+        print(f"err: {i}", file=sys.stderr)
+        time.sleep(1)
+
+
+def consume_memory(size):
+    """Function to consume amount of memory specified by 'size' in megabytes"""
+    # Create a list of size MB
+    bytes_in_mb = 1024 * 1024
+    _memory = bytearray(size * bytes_in_mb)  # noqa
+
+
+def main(duration, cpu_load, memory_size):
+    print("Printing something to STDOUT at start")
+    print("Printing something to STDERR at start", file=sys.stderr)
+    consume_memory(memory_size)
+    consume_cpu(duration, cpu_load)
+    print(
+        f"Test completed. Consumed {memory_size} MB for {duration} seconds with CPU load factor {cpu_load}."
+    )
+    print("Printing something to STDOUT at finish")
+    print("Printing something to STDERR at finish", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Test script to consume CPU and memory."
+    )
+    parser.add_argument(
+        "--duration", type=int, default=60, help="Duration to run the test in seconds."
+    )
+    parser.add_argument(
+        "--cpu-load", type=int, default=10000, help="Load factor to simulate CPU usage."
+    )
+    parser.add_argument(
+        "--memory-size",
+        type=int,
+        default=10,
+        help="Amount of memory to allocate in MB.",
+    )
+
+    args = parser.parse_args()
+    main(args.duration, args.cpu_load, args.memory_size)

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
-# envlist = lint,typing,py37,py38,py39,py310,py311,py312,pypy3
-envlist = lint,py37,py38,py39,py310,py311,py312,pypy3
+envlist = lint,typing,py38,py39,py310,py311,py312,pypy3
+# envlist = lint,py37,py38,py39,py310,py311,py312,pypy3
 skip_missing_interpreters = True
 isolated_build = True
 minversion = 3.3.0
@@ -26,12 +26,12 @@ deps =
 commands =
     flake8 src test
 
-# [testenv:typing]
-# deps =
-#     mypy
-#    {[testenv]deps}
-# commands =
-#     mypy src test
+[testenv:typing]
+deps =
+    mypy
+   {[testenv]deps}
+commands =
+    mypy src test
 
 [pytest]
 # addopts = --cov=datalad_installer --no-cov-on-fail

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ commands =
     mypy src test
 
 [pytest]
-addopts = --cov=datalad_installer --no-cov-on-fail
+# addopts = --cov=datalad_installer --no-cov-on-fail
 filterwarnings = error
 norecursedirs = test/data
 markers =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
-envlist = lint,typing,py37,py38,py39,py310,py311,py312,pypy3
+# envlist = lint,typing,py37,py38,py39,py310,py311,py312,pypy3
+envlist = lint,py37,py38,py39,py310,py311,py312,pypy3
 skip_missing_interpreters = True
 isolated_build = True
 minversion = 3.3.0
@@ -25,12 +26,12 @@ deps =
 commands =
     flake8 src test
 
-[testenv:typing]
-deps =
-    mypy
-    {[testenv]deps}
-commands =
-    mypy src test
+# [testenv:typing]
+# deps =
+#     mypy
+#    {[testenv]deps}
+# commands =
+#     mypy src test
 
 [pytest]
 # addopts = --cov=datalad_installer --no-cov-on-fail


### PR DESCRIPTION
Adds:
 - --outputs
 - --capture-outputs
 - --record-types
 - Tests for process_outputs
 
Runs the monitoring loop in a thread, which should prevent monitoring from blocking the main process, but this is not tested.