### PR TITLE
Track spikes, bugfixes, test execution, and enable osx

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,8 +25,8 @@ jobs:
       fail-fast: true
       matrix:
         os:
-          # - macos-12
-          # - macos-latest
+          - macos-12
+          - macos-latest
           # - windows-latest
           - ubuntu-latest
         python-version:
@@ -38,25 +38,16 @@ jobs:
           - 'pypy-3.8'
           - 'pypy-3.9'
           - 'pypy-3.10'
-        # exclude:
-        #   # No older Pythons on arm64 macos-latest
-        #   - python-version: '3.7'
-        #     os: macos-latest
-        #   - python-version: '3.8'
-        #     os: macos-latest
-        #   - python-version: '3.9'
-        #     os: macos-latest
-        #   - python-version: 'pypy-3.8'
-        #     os: macos-latest
-        #   - python-version: 'pypy-3.9'
-        #     os: macos-latest
-        # include:
-        #   - python-version: '3.7'
-        #     toxenv: lint
-        #     os: ubuntu-latest
-        #   - python-version: '3.7'
-        #     toxenv: typing
-        #     os: ubuntu-latest
+        exclude:
+          # No older Pythons on arm64 macos-latest
+          - python-version: '3.8'
+            os: macos-latest
+          - python-version: '3.9'
+            os: macos-latest
+          - python-version: 'pypy-3.8'
+            os: macos-latest
+          - python-version: 'pypy-3.9'
+            os: macos-latest
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -77,9 +77,6 @@ jobs:
       - name: Run tests
         run: tox -e py -- -vv --cov-report=xml
 
-      - name: Run smoke tests
-        run: ./smoke-tests.sh
-
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ options:
                         .duct/logs/{datetime_filesafe}-{pid}_)
   --sample-interval SAMPLE_INTERVAL, --s-i SAMPLE_INTERVAL
                         Interval in seconds between status checks of the
-                        running process. (default: 1.0)
+                        running process. Sample interval should be larger than
+                        the runtime of the process or `duct` may underreport
+                        the number of processes started. (default: 1.0)
   --report-interval REPORT_INTERVAL, --r-i REPORT_INTERVAL
                         Interval in seconds at which to report aggregated
                         data. (default: 60.0)

--- a/README.md
+++ b/README.md
@@ -9,28 +9,45 @@ A process wrapper script that monitors the execution of a command.
 ```shell
 > duct --help
 
-usage: duct [-h] [--sample-interval SAMPLE_INTERVAL]
-            [--output_prefix OUTPUT_PREFIX]
-            [--report-interval REPORT_INTERVAL]
+usage: duct [-h] [-p OUTPUT_PREFIX] [--sample-interval SAMPLE_INTERVAL]
+            [--report-interval REPORT_INTERVAL] [-c {all,none,stdout,stderr}]
+            [-o {all,none,stdout,stderr}]
+            [-t {all,system-summary,processes-samples}]
             command [arguments ...]
 
-Duct creates a new session to run a command and all its child processes, and
-the collects metrics for all processes in the session.
+Gathers metrics on a command and all its child processes.
 
 positional arguments:
   command               The command to execute.
-  arguments             Arguments for the command.
+  arguments             Arguments for the command. (default: None)
 
 options:
   -h, --help            show this help message and exit
-  --sample-interval SAMPLE_INTERVAL
+  -p OUTPUT_PREFIX, --output-prefix OUTPUT_PREFIX
+                        File string format to be used as a prefix for the
+                        files -- the captured stdout and stderr and the
+                        resource usage logs. The understood variables are
+                        {datetime}, {datetime_filesafe}, and {pid}. Leading
+                        directories will be created if they do not exist. You
+                        can also provide value via DUCT_OUTPUT_PREFIX env
+                        variable. (default:
+                        .duct/logs/{datetime_filesafe}-{pid}_)
+  --sample-interval SAMPLE_INTERVAL, --s-i SAMPLE_INTERVAL
                         Interval in seconds between status checks of the
-                        running process.
-  --output_prefix OUTPUT_PREFIX
-                        Directory in which all logs will be saved.
-  --report-interval REPORT_INTERVAL
+                        running process. (default: 1.0)
+  --report-interval REPORT_INTERVAL, --r-i REPORT_INTERVAL
                         Interval in seconds at which to report aggregated
-                        data.
+                        data. (default: 60.0)
+  -c {all,none,stdout,stderr}, --capture-outputs {all,none,stdout,stderr}
+                        Record stdout, stderr, all, or none to log files. You
+                        can also provide value via DUCT_CAPTURE_OUTPUTS env
+                        variable. (default: all)
+  -o {all,none,stdout,stderr}, --outputs {all,none,stdout,stderr}
+                        Print stdout, stderr, all, or none to stdout/stderr
+                        respectively. (default: all)
+  -t {all,system-summary,processes-samples}, --record-types {all,system-summary,processes-samples}
+                        Record system-summary, processes-samples, or all
+                        (default: all)
 ```
 
 ## Testing:

--- a/smoke-tests.sh
+++ b/smoke-tests.sh
@@ -1,4 +1,0 @@
-# Smoketests
-rm -rf .duct/*
-duct --report-interval 2 --sample-interval 0.5 ./test_script.py -- --duration 6 --cpu-load 50000 --memory-size 500
-find .duct/ -name '*.json' -exec sh -c 'echo "File: $1)"; cat "$1" | jq' _ {} \;

--- a/src/duct.py
+++ b/src/duct.py
@@ -157,12 +157,9 @@ class Report:
             print(Colors.OKGREEN)
         else:
             print(Colors.FAIL)
-
-        print("-----------------------------------------------------")
-        print("                    duct report")
-        print("-----------------------------------------------------")
         print(f"Exit Code: {self.process.returncode}")
         print(f"{Colors.OKCYAN}Command: {self.command}")
+        print(f"Log files location: {self.output_prefix}")
         print(f"Wall Clock Time: {self.elapsed_time}")
         print(f"Number of Processes: {len(self.max_values)}")
         for pid, values in self.max_values.items():
@@ -354,11 +351,8 @@ def main():
         stderr_file = stderr
 
     full_command = " ".join([str(args.command)] + args.arguments)
-    print(f"{Colors.OKCYAN}-----------------------------------------------------")
-    print(f"duct is executing {full_command}...")
-    print()
-    print(f"Log files will be written to {formatted_output_prefix}")
-    print(f"-----------------------------------------------------{Colors.ENDC}")
+    print(f"{Colors.OKCYAN}duct is executing {full_command}...")
+    print(f"Log files will be written to {formatted_output_prefix}{Colors.ENDC}")
     process = subprocess.Popen(
         [str(args.command)] + args.arguments,
         stdout=stdout_file,
@@ -408,7 +402,6 @@ def main():
         stderr_file.close()
         stderr.close()
     report.finalize()
-    print(f"Log files location: {report.output_prefix}")
 
 
 if __name__ == "__main__":

--- a/src/duct.py
+++ b/src/duct.py
@@ -398,7 +398,11 @@ def execute(args):
         stderr=stderr_file,
         preexec_fn=os.setsid,
     )
-    session_id = os.getsid(process.pid)  # Get session ID of the new process
+    try:
+        session_id = os.getsid(process.pid)  # Get session ID of the new process
+    except ProcessLookupError:  # process has already finished
+        session_id = None
+
     report = Report(
         args.command,
         args.arguments,

--- a/src/duct.py
+++ b/src/duct.py
@@ -172,8 +172,12 @@ class Report:
         print(f"{Colors.OKCYAN}Command: {self.command}")
         print(f"Log files location: {self.output_prefix}")
         print(f"Wall Clock Time: {self.elapsed_time}")
-        print(f"Memory Peak Usage: {self.max_values['totals']['pmem']}%")
-        print(f"CPU Peak Usage: {self.max_values['totals']['pcpu']}%")
+        print(
+            f"Memory Peak Usage: {self.max_values.get('totals', {}).get('pmem', 'unknown')}%"
+        )
+        print(
+            f"CPU Peak Usage: {self.max_values.get('totals', {}).get('pcpu', 'unknown')}%"
+        )
 
     def __repr__(self):
         return json.dumps(

--- a/src/duct.py
+++ b/src/duct.py
@@ -357,6 +357,11 @@ def ensure_directories(path: str) -> None:
 
 
 def main():
+    args = create_and_parse_args()
+    execute(args)
+
+
+def execute(args):
     """A wrapper to execute a command, monitor and log the process details."""
     args = create_and_parse_args()
     datetime_filesafe = datetime.now().strftime("%Y.%m.%dT%H.%M.%S")

--- a/src/duct.py
+++ b/src/duct.py
@@ -52,6 +52,7 @@ class Report:
         self.arguments = arguments
         self.session_id = session_id
         self.gpus = []
+        self.env = None
         self.number = 0
         self.system_info = {}
         self.output_prefix = output_prefix
@@ -103,13 +104,14 @@ class Report:
             except subprocess.CalledProcessError:
                 self.gpus = ["Failed to query GPU info"]
 
-    def update_max_resources(self, maxes, sample):
+    @staticmethod
+    def update_max_resources(maxes, sample):
         for pid in sample:
             if pid in maxes:
                 for key, value in sample[pid].items():
                     maxes[pid][key] = max(maxes[pid].get(key, value), value)
             else:
-                maxes[pid] = sample[pid]
+                maxes[pid] = sample[pid].copy()
 
     def collect_sample(self):
         process_data = {}

--- a/src/duct.py
+++ b/src/duct.py
@@ -420,6 +420,7 @@ def main():
             system_logs.write(str(report))
 
     process.wait()
+    report.update_max_resources(report.max_values, report._sample)
     report.process = process
     if isinstance(stdout, TailPipe):
         stdout_file.close()

--- a/src/duct.py
+++ b/src/duct.py
@@ -151,7 +151,7 @@ class Report:
                         "timestamp": datetime.now().astimezone().isoformat(),
                     }
         except subprocess.CalledProcessError:
-            process_data["error"] = "Failed to query process data"
+            pass
         return process_data
 
     def write_pid_samples(self):
@@ -199,7 +199,7 @@ def monitor_process(report, process, report_interval, sample_interval):
         totals = report.calculate_total_usage(sample)
         report.update_max_resources(sample, totals)
         report.update_max_resources(report._sample, sample)
-        if report.elapsed_time >= (report.number + 1) * report_interval:
+        if report.elapsed_time >= report.number * report_interval:
             report.write_pid_samples()
             report.update_max_resources(report.max_values, report._sample)
             report._sample = defaultdict(dict)  # Reset sample
@@ -406,7 +406,6 @@ def main():
             target=monitor_process, args=monitoring_args
         )
         monitoring_thread.start()
-        monitoring_thread.join()
 
     if args.record_types in ["all", "system-summary"]:
         report.collect_environment()

--- a/src/duct.py
+++ b/src/duct.py
@@ -166,6 +166,16 @@ class Report:
             values.pop("timestamp")  # Meaningless
             print(f"    {pid} Max Usage: {values}")
 
+    def __repr__(self):
+        return json.dumps(
+            {
+                "Command": self.command,
+                "System": self.system_info,
+                "ENV": self.env,
+                "GPU": self.gpus,
+            }
+        )
+
 
 def monitor_process(report, process, report_interval, sample_interval):
     while True:

--- a/src/duct.py
+++ b/src/duct.py
@@ -330,7 +330,7 @@ def prepare_outputs(
     elif capture_outputs in ["all", "stdout"] and outputs in ["none", "stderr"]:
         stdout = open(f"{output_prefix}stdout", "w")
     elif capture_outputs in ["none", "stderr"] and outputs in ["all", "stdout"]:
-        stdout = subprocess.PIPE
+        stdout = None
     else:
         stdout = subprocess.DEVNULL
 
@@ -340,7 +340,7 @@ def prepare_outputs(
     elif capture_outputs in ["all", "stderr"] and outputs in ["none", "stdout"]:
         stderr = open(f"{output_prefix}stderr", "w")
     elif capture_outputs in ["none", "stdout"] and outputs in ["all", "stderr"]:
-        stderr = subprocess.PIPE
+        stderr = None
     else:
         stderr = subprocess.DEVNULL
     return stdout, stderr

--- a/src/duct.py
+++ b/src/duct.py
@@ -217,7 +217,9 @@ def create_and_parse_args():
         "--s-i",
         type=float,
         default=float(os.getenv("DUCT_SAMPLE_INTERVAL", "1.0")),
-        help="Interval in seconds between status checks of the running process.",
+        help="Interval in seconds between status checks of the running process. "
+        "Sample interval should be larger than the runtime of the process or `duct` may "
+        "underreport the number of processes started.",
     )
     parser.add_argument(
         "--report-interval",

--- a/src/duct.py
+++ b/src/duct.py
@@ -76,7 +76,7 @@ class Report:
 
     def get_system_info(self):
         """Gathers system information related to CPU, GPU, memory, and environment variables."""
-        self.system_info["uid"] = os.environ["USER"]
+        self.system_info["uid"] = os.environ.get("USER")
         self.system_info["memory_total"] = os.sysconf("SC_PAGE_SIZE") * os.sysconf(
             "SC_PHYS_PAGES"
         )

--- a/test/test_aggregation.py
+++ b/test/test_aggregation.py
@@ -1,2 +1,0 @@
-def test_sanity():
-    pass

--- a/test/test_execution.py
+++ b/test/test_execution.py
@@ -1,9 +1,9 @@
 import argparse
 import os
-from pathlib import Path
 import shutil
 from unittest import mock
 import pytest
+from utils import assert_files
 from duct import execute
 
 
@@ -27,10 +27,7 @@ def test_sanity_green(temp_output_dir):
     execute(args)
     # When runtime < sample_interval, we won't have a usage.json
     expected_files = ["stdout", "stderr", "info.json"]
-    for file_path in expected_files:
-        assert Path(
-            temp_output_dir + file_path
-        ).exists(), f"Expected file does not exist: {file_path}"
+    assert_files(temp_output_dir, expected_files, exists=True)
 
 
 def test_sanity_red(temp_output_dir):
@@ -50,17 +47,10 @@ def test_sanity_red(temp_output_dir):
 
     # We still should execute normally
     expected_files = ["stdout", "stderr", "info.json"]
-    for file_path in expected_files:
-        assert Path(
-            temp_output_dir + file_path
-        ).exists(), f"Expected file does not exist: {file_path}"
-
+    assert_files(temp_output_dir, expected_files, exists=True)
     # But no polling of the already failed command
     not_expected_files = ["usage.json"]
-    for file_path in not_expected_files:
-        assert not Path(
-            temp_output_dir + file_path
-        ).exists(), f"Unexpected file should not exist: {file_path}"
+    assert_files(temp_output_dir, not_expected_files, exists=False)
 
 
 def test_outputs_full(temp_output_dir):
@@ -76,10 +66,7 @@ def test_outputs_full(temp_output_dir):
     )
     execute(args)
     expected_files = ["stdout", "stderr", "info.json", "usage.json"]
-    for file_path in expected_files:
-        assert Path(
-            temp_output_dir + file_path
-        ).exists(), f"Expected file does not exist: {file_path}"
+    assert_files(temp_output_dir, expected_files, exists=True)
 
 
 def test_outputs_passthrough(temp_output_dir):
@@ -95,16 +82,9 @@ def test_outputs_passthrough(temp_output_dir):
     )
     execute(args)
     expected_files = ["info.json", "usage.json"]
-    for file_path in expected_files:
-        assert Path(
-            temp_output_dir + file_path
-        ).exists(), f"Expected file does not exist: {file_path}"
-
+    assert_files(temp_output_dir, expected_files, exists=True)
     not_expected_files = ["stdout", "stderr"]
-    for file_path in not_expected_files:
-        assert not Path(
-            temp_output_dir + file_path
-        ).exists(), f"Unexpected file should not exist: {file_path}"
+    assert_files(temp_output_dir, not_expected_files, exists=False)
 
 
 def test_outputs_capture(temp_output_dir):
@@ -122,10 +102,7 @@ def test_outputs_capture(temp_output_dir):
     # TODO make this work assert mock.call("this is of test of STDOUT\n") not in mock_stdout.write.mock_calls
 
     expected_files = ["stdout", "stderr", "info.json", "usage.json"]
-    for file_path in expected_files:
-        assert Path(
-            temp_output_dir + file_path
-        ).exists(), f"Expected file does not exist: {file_path}"
+    assert_files(temp_output_dir, expected_files, exists=True)
 
 
 def test_outputs_none(temp_output_dir):
@@ -143,16 +120,10 @@ def test_outputs_none(temp_output_dir):
     # assert mock.call("this is of test of STDOUT\n") not in mock_stdout.write.mock_calls
 
     expected_files = ["info.json", "usage.json"]
-    for file_path in expected_files:
-        assert Path(
-            temp_output_dir + file_path
-        ).exists(), f"Expected file does not exist: {file_path}"
+    assert_files(temp_output_dir, expected_files, exists=True)
 
     not_expected_files = ["stdout", "stderr"]
-    for file_path in not_expected_files:
-        assert not Path(
-            temp_output_dir + file_path
-        ).exists(), f"Unexpected file should not exist: {file_path}"
+    assert_files(temp_output_dir, not_expected_files, exists=False)
 
 
 def test_exit_before_first_sample(temp_output_dir):
@@ -168,16 +139,9 @@ def test_exit_before_first_sample(temp_output_dir):
     )
     execute(args)
     expected_files = ["stdout", "stderr", "info.json"]
-    for file_path in expected_files:
-        assert Path(
-            temp_output_dir + file_path
-        ).exists(), f"Expected file does not exist: {file_path}"
-
+    assert_files(temp_output_dir, expected_files, exists=True)
     not_expected_files = ["usage.json"]
-    for file_path in not_expected_files:
-        assert not Path(
-            temp_output_dir + file_path
-        ).exists(), f"Unexpected file should not exist: {file_path}"
+    assert_files(temp_output_dir, not_expected_files, exists=False)
 
 
 def test_run_less_than_report_interval(temp_output_dir):
@@ -194,7 +158,4 @@ def test_run_less_than_report_interval(temp_output_dir):
     execute(args)
     # Specifically we need to assert that usage.json gets written anyway.
     expected_files = ["stdout", "stderr", "usage.json", "info.json"]
-    for file_path in expected_files:
-        assert Path(
-            temp_output_dir + file_path
-        ).exists(), f"Expected file does not exist: {file_path}"
+    assert_files(temp_output_dir, expected_files, exists=True)

--- a/test/test_execution.py
+++ b/test/test_execution.py
@@ -8,9 +8,9 @@ from duct import execute
 
 
 @pytest.fixture
-def temp_output_dir(tmpdir):
-    yield str(tmpdir) + os.sep
-    shutil.rmtree(tmpdir)
+def temp_output_dir(tmp_path):
+    yield str(tmp_path) + os.sep
+    shutil.rmtree(tmp_path)
 
 
 def test_sanity_green(temp_output_dir):

--- a/test/test_execution.py
+++ b/test/test_execution.py
@@ -1,0 +1,169 @@
+import argparse
+import os
+from pathlib import Path
+import shutil
+import pytest
+from duct import execute
+
+
+@pytest.fixture
+def temp_output_dir(tmpdir):
+    yield str(tmpdir) + os.sep
+    shutil.rmtree(tmpdir)
+
+
+def test_sanity(temp_output_dir):
+    args = argparse.Namespace(
+        command="echo",
+        arguments=["hello", "world"],
+        output_prefix=temp_output_dir,
+        sample_interval=1.0,
+        report_interval=60.0,
+        capture_outputs="all",
+        outputs="all",
+        record_types="all",
+    )
+    execute(args)
+    # When runtime < sample_interval, we won't have a usage.json
+    expected_files = ["stdout", "stderr", "info.json"]
+    for file_path in expected_files:
+        assert Path(
+            temp_output_dir + file_path
+        ).exists(), f"Expected file does not exist: {file_path}"
+
+
+def test_outputs_full(temp_output_dir):
+    args = argparse.Namespace(
+        command="./test_script.py",
+        arguments=["--duration", "1"],
+        output_prefix=temp_output_dir,
+        sample_interval=0.01,
+        report_interval=0.1,
+        capture_outputs="all",
+        outputs="all",
+        record_types="all",
+    )
+    execute(args)
+    expected_files = ["stdout", "stderr", "info.json", "usage.json"]
+    for file_path in expected_files:
+        assert Path(
+            temp_output_dir + file_path
+        ).exists(), f"Expected file does not exist: {file_path}"
+
+
+def test_outputs_passthrough(temp_output_dir):
+    args = argparse.Namespace(
+        command="./test_script.py",
+        arguments=["--duration", "1"],
+        output_prefix=temp_output_dir,
+        sample_interval=0.01,
+        report_interval=0.1,
+        capture_outputs="none",
+        outputs="all",
+        record_types="all",
+    )
+    execute(args)
+    expected_files = ["info.json", "usage.json"]
+    for file_path in expected_files:
+        assert Path(
+            temp_output_dir + file_path
+        ).exists(), f"Expected file does not exist: {file_path}"
+
+    not_expected_files = ["stdout", "stderr"]
+    for file_path in not_expected_files:
+        assert not Path(
+            temp_output_dir + file_path
+        ).exists(), f"Expected file does not exist: {file_path}"
+
+
+def test_outputs_capture(temp_output_dir):
+    args = argparse.Namespace(
+        command="./test_script.py",
+        arguments=["--duration", "1"],
+        output_prefix=temp_output_dir,
+        sample_interval=0.01,
+        report_interval=0.1,
+        capture_outputs="all",
+        outputs="none",
+        record_types="all",
+    )
+    execute(args)
+    # TODO make this work assert mock.call("this is of test of STDOUT\n") not in mock_stdout.write.mock_calls
+
+    expected_files = ["stdout", "stderr", "info.json", "usage.json"]
+    for file_path in expected_files:
+        assert Path(
+            temp_output_dir + file_path
+        ).exists(), f"Expected file does not exist: {file_path}"
+
+
+def test_outputs_none(temp_output_dir):
+    args = argparse.Namespace(
+        command="./test_script.py",
+        arguments=["--duration", "1"],
+        output_prefix=temp_output_dir,
+        sample_interval=0.01,
+        report_interval=0.1,
+        capture_outputs="none",
+        outputs="none",
+        record_types="all",
+    )
+    execute(args)
+    # assert mock.call("this is of test of STDOUT\n") not in mock_stdout.write.mock_calls
+
+    expected_files = ["info.json", "usage.json"]
+    for file_path in expected_files:
+        assert Path(
+            temp_output_dir + file_path
+        ).exists(), f"Expected file does not exist: {file_path}"
+
+    not_expected_files = ["stdout", "stderr"]
+    for file_path in not_expected_files:
+        assert not Path(
+            temp_output_dir + file_path
+        ).exists(), f"Expected file does not exist: {file_path}"
+
+
+def test_exit_before_first_sample(temp_output_dir):
+    args = argparse.Namespace(
+        command="ls",
+        arguments=[],
+        output_prefix=temp_output_dir,
+        sample_interval=0.1,
+        report_interval=0.1,
+        capture_outputs="all",
+        outputs="none",
+        record_types="all",
+    )
+    execute(args)
+    expected_files = ["stdout", "stderr", "info.json"]
+    for file_path in expected_files:
+        assert Path(
+            temp_output_dir + file_path
+        ).exists(), f"Expected file does not exist: {file_path}"
+
+    not_expected_files = ["usage.json"]
+    for file_path in not_expected_files:
+        assert not Path(
+            temp_output_dir + file_path
+        ).exists(), f"Expected file does not exist: {file_path}"
+
+
+def test_run_less_than_report_interval(temp_output_dir):
+    args = argparse.Namespace(
+        command="sleep",
+        arguments=["0.01"],
+        output_prefix=temp_output_dir,
+        sample_interval=0.001,
+        report_interval=0.1,
+        capture_outputs="all",
+        outputs="none",
+        record_types="all",
+    )
+    execute(args)
+    # Specifically we need to assert that usage.json gets written anyway.
+    expected_files = ["stdout", "stderr", "usage.json", "info.json"]
+    for file_path in expected_files:
+        assert Path(
+            temp_output_dir + file_path
+        ).exists(), f"Expected file does not exist: {file_path}"

--- a/test/test_prepare_outputs.py
+++ b/test/test_prepare_outputs.py
@@ -50,14 +50,14 @@ def test_prepare_outputs_all_none():
 def test_prepare_outputs_none_stdout():
     output_prefix = "test_outputs_"
     stdout, stderr = prepare_outputs("none", "stdout", output_prefix)
-    assert stdout == subprocess.PIPE
+    assert stdout is None
     assert stderr == subprocess.DEVNULL
 
 
 def test_prepare_outputs_none_stderr():
     output_prefix = "test_outputs_"
     stdout, stderr = prepare_outputs("none", "stderr", output_prefix)
-    assert stderr == subprocess.PIPE
+    assert stderr is None
     assert stdout == subprocess.DEVNULL
 
 

--- a/test/test_report.py
+++ b/test/test_report.py
@@ -1,0 +1,37 @@
+from collections import defaultdict
+from duct import Report
+
+ex0 = {"pid1": {"pcpu": 0.0}}
+ex1 = {"pid1": {"pcpu": 1.0}}
+ex2 = {"pid2": {"pcpu": 1.0}}
+ex2pids = {"pid1": {"pcpu": 0.0}, "pid2": {"pcpu": 0.0}}
+
+
+def test_update_max_resources_initial_values_one_pid():
+    maxes = defaultdict(dict)
+    Report.update_max_resources(maxes, ex0)
+    assert maxes == ex0
+
+
+def test_update_max_resources_max_values_one_pid():
+    maxes = defaultdict(dict)
+    Report.update_max_resources(maxes, ex0)
+    Report.update_max_resources(maxes, ex1)
+    assert maxes == ex1
+
+
+def test_update_max_resources_initial_values_two_pids():
+    maxes = defaultdict(dict)
+    Report.update_max_resources(maxes, ex2pids)
+    assert maxes == ex2pids
+
+
+def test_update_max_resources_max_update_values_two_pids():
+    maxes = defaultdict(dict)
+    Report.update_max_resources(maxes, ex2pids)
+    Report.update_max_resources(maxes, ex1)
+    Report.update_max_resources(maxes, ex2)
+    assert maxes.keys() == ex2pids.keys()
+    assert maxes != ex2pids
+    assert maxes["pid1"] == ex1["pid1"]
+    assert maxes["pid2"] == ex2["pid2"]

--- a/test/utils.py
+++ b/test/utils.py
@@ -1,4 +1,5 @@
 from io import BytesIO
+from pathlib import Path
 
 
 class MockStream:
@@ -9,3 +10,16 @@ class MockStream:
 
     def getvalue(self):
         return self.buffer.getvalue()
+
+
+def assert_files(parent_dir, file_list, exists=True):
+    if exists:
+        for file_path in file_list:
+            assert Path(
+                parent_dir + file_path
+            ).exists(), f"Expected file does not exist: {file_path}"
+    else:
+        for file_path in file_list:
+            assert not Path(
+                parent_dir + file_path
+            ).exists(), f"Unexpected file should not exist: {file_path}"

--- a/test_script.py
+++ b/test_script.py
@@ -21,7 +21,8 @@ def consume_memory(size):
 
 
 def main(duration, cpu_load, memory_size):
-    print("this is of test of STDERR: ERRRRRRRRRRRRRRR", file=sys.stderr)
+    print("this is of test of STDOUT")
+    print("this is of test of STDERR", file=sys.stderr)
     consume_memory(memory_size)
     consume_cpu(duration, cpu_load)
     print(

--- a/test_script.py
+++ b/test_script.py
@@ -21,8 +21,8 @@ def consume_memory(size):
 
 
 def main(duration, cpu_load, memory_size):
-    consume_memory(memory_size)
     print("this is of test of STDERR: ERRRRRRRRRRRRRRR", file=sys.stderr)
+    consume_memory(memory_size)
     consume_cpu(duration, cpu_load)
     print(
         f"Test completed. Consumed {memory_size} MB for {duration} seconds with CPU load factor {cpu_load}."


### PR DESCRIPTION
`{output_prefix}usage.json`  now includes "totals".
`{"183380": {"pcpu": 101.0, "pmem": 0.0, "rss": 11104, "vsz": 232924, "timestamp": "2024-06-04T10:26:59.614005-05:00"}, "totals": {"pmem": 0.0, "pcpu": 101.0}}`

A run now looks like:

```
duct is executing ./test_script.py --duration 3 --memory-size 10000...
Log files will be written to .duct/logs/2024.06.04T10.42.58-185114_
this is of test of STDERR: ERRRRRRRRRRRRRRR
Test completed. Consumed 10000 MB for 3 seconds with CPU load factor 10000.

Exit Code: 0
Command: ./test_script.py --duration 3 --memory-size 10000
Log files location: .duct/logs/2024.06.04T10.42.58-185114_
Wall Clock Time: 8.781145811080933
Memory Peak Usage: 30.9%
CPU Peak Usage: 141.0%
```
with memory peak usage and cpu peak usage added, and number of pids and pid info now left out of the final report

Fixes: https://github.com/con/duct/issues/22
Fixes: https://github.com/con/duct/issues/39
Fixes: https://github.com/con/duct/issues/36
Fixes: https://github.com/con/duct/issues/6
https://github.com/con/duct/issues/15