### PR TITLE
Fix test script: Consume memory the whole time, not just the end

### DIFF
--- a/test_script.py
+++ b/test_script.py
@@ -17,13 +17,13 @@ def consume_memory(size):
     """Function to consume amount of memory specified by 'size' in megabytes"""
     # Create a list of size MB
     bytes_in_mb = 1024 * 1024
-    _memory = bytearray(size * bytes_in_mb)  # noqa
+    return bytearray(size * bytes_in_mb)
 
 
 def main(duration, cpu_load, memory_size):
     print("this is of test of STDOUT")
     print("this is of test of STDERR", file=sys.stderr)
-    consume_memory(memory_size)
+    _mem_hold = consume_memory(memory_size)  # noqa
     consume_cpu(duration, cpu_load)
     print(
         f"Test completed. Consumed {memory_size} MB for {duration} seconds with CPU load factor {cpu_load}."


### PR DESCRIPTION
```
duct ./test_script.py -- --duration 3 --memory-size 1000                        
duct is executing ./test_script.py --duration 3 --memory-size 1000...
Log files will be written to .duct/logs/2024.06.07T10.26.03-527426_
this is of test of STDERR
this is of test of STDOUT
Test completed. Consumed 1000 MB for 3 seconds with CPU load factor 10000.

Exit Code: 0
Command: ./test_script.py --duration 3 --memory-size 1000
Log files location: .duct/logs/2024.06.07T10.26.03-527426_
Wall Clock Time: 3.3988728523254395
Memory Peak Usage: 3.1%
CPU Peak Usage: 119.0%
```