### PR TITLE
Rewrite README update script in Python and remove from pre-commit

### DIFF
--- a/.github/workflows/readme-updated.yaml
+++ b/.github/workflows/readme-updated.yaml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Update README.md helptext
         run: |
-          ./.update-readme-help.sh
+          ./.update-readme-help.py
 
       - name: Ensure no diff
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
     hooks:
       - id: update-readme
         name: Update README with --help output
-        entry: ./.update-readme-help.sh
+        entry: ./.update-readme-help.py
         language: system
   - repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,12 +32,6 @@ repos:
       - id: codespell
   - repo: local
     hooks:
-      - id: update-readme
-        name: Update README with --help output
-        entry: ./.update-readme-help.py
-        language: system
-  - repo: local
-    hooks:
       - id: yamllint
         name: "YAML linting with yamllint"
         entry: yamllint

--- a/.update-readme-help.py
+++ b/.update-readme-help.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import re
+import subprocess
+
+help_content = subprocess.run(
+    ["duct", "--help"], check=True, text=True, encoding="utf-8", stdout=subprocess.PIPE
+).stdout
+
+readme = Path("README.md")
+text = readme.read_text(encoding="utf-8")
+text = re.sub(
+    r"(?<=<!--- BEGIN HELP -->\n).*(?=^<!--- END HELP -->)",
+    help_content,
+    text,
+    flags=re.S | re.M,
+)
+readme.write_text(text, encoding="utf-8")

--- a/.update-readme-help.sh
+++ b/.update-readme-help.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-set -e
-rm -f .help_content.txt
-duct --help > .help_content.txt
-sed -i '/<\!--- BEGIN HELP -->/,/<\!--- END HELP -->/{//!d;}' README.md
-sed -i '/<\!--- BEGIN HELP -->/r .help_content.txt' README.md && rm -f .help_content.txt

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -28,11 +28,6 @@ The project uses a number of automated checks to limit tedious work.  The
 checks will be run automatically prior to commit if `pre-commit
 <https://pre-commit.com>`_ is installed in your environment.
 
-Note: ``README.md`` is automatically updated to include the help text, but
-because argparse changed its output in Python 3.10+, CI enforces the 3.10+ help
-text.  Please either use 3.10+ or drop the "optional arguments" vs "options"
-diff.
-
 
 Testing
 -------


### PR DESCRIPTION
* `.update-readme-help.sh` benefits from being rewritten in Python because:
    * The syntax for `sed -i` with no extension differs between Linux and macOS, and thus the current shell script is not portable.
    * The Python script is more efficient, as it only needs to pass over the file once, where as the shell script processes the file twice.

* Running `.update-readme-help.sh` via pre-commit is problematic, as it requires `duct` to be installed in the current Python environment, yet no provision is made for this.  Unless you can come up with a simple, clean way to install `duct` in editable mode in some virtualenv, I think it's better to just leave this out of pre-commit.