### PR TITLE
Set `fail-fast` in `test.yml` back to `false`

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,7 +23,7 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os:
           - macos-12


### PR DESCRIPTION
`fail-fast` in `test.yml` was set to `true` in 213eabd in #14.  The commit message states that the change was temporary, yet this part was not reverted in bec8c95.  This PR sets `fail-fast` back to `false` so that PR authors will properly be informed if more than one test job fails.