### PR TITLE
Move markdown comment markers out of code block

### DIFF
--- a/.update-readme-help.py
+++ b/.update-readme-help.py
@@ -7,10 +7,11 @@ help_content = subprocess.run(
     ["duct", "--help"], check=True, text=True, encoding="utf-8", stdout=subprocess.PIPE
 ).stdout
 
+help_content = f"```shell\n>duct --help\n\n{help_content}\n```\n"
 readme = Path("README.md")
 text = readme.read_text(encoding="utf-8")
 text = re.sub(
-    r"(?<=<!--- BEGIN HELP -->\n).*(?=^<!--- END HELP -->)",
+    r"(?<=<!-- BEGIN HELP -->\n).*(?=^<!-- END HELP -->)",
     help_content,
     text,
     flags=re.S | re.M,

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ Try it out!
 
 A process wrapper script that monitors the execution of a command.
 
+<!-- BEGIN HELP -->
 ```shell
-> duct --help
+>duct --help
 
-<!--- BEGIN HELP -->
 usage: duct [-h] [--version] [-p OUTPUT_PREFIX]
             [--sample-interval SAMPLE_INTERVAL]
             [--report-interval REPORT_INTERVAL] [-c {all,none,stdout,stderr}]
@@ -62,5 +62,6 @@ options:
   -t {all,system-summary,processes-samples}, --record-types {all,system-summary,processes-samples}
                         Record system-summary, processes-samples, or all
                         (default: all)
-<!--- END HELP -->
+
 ```
+<!-- END HELP -->


### PR DESCRIPTION
Fixes https://github.com/con/duct/issues/88

The problem wasn't  the marker, it was that it was inside of a literal block. 