### PR TITLE
Prepare for auto-powered releases

### DIFF
--- a/.autorc
+++ b/.autorc
@@ -13,4 +13,14 @@
             }
         ]
     ]
+    "labels": [
+      { "releaseType": "major", "name": "semver-major" },
+      { "releaseType": "minor", "name": "semver-minor" },
+      { "releaseType": "patch", "name": "semver-patch" },
+      { "releaseType": "none", "name": "semver-dependencies" },
+      { "releaseType": "none", "name": "semver-documentation" },
+      { "releaseType": "none", "name": "semver-internal" },
+      { "releaseType": "none", "name": "semver-performance" },
+      { "releaseType": "none", "name": "semver-tests" }
+    ]
 }

--- a/.autorc
+++ b/.autorc
@@ -1,6 +1,6 @@
 {
     "onlyPublishWithReleaseLabel": true,
-    "baseBranch": "master",
+    "baseBranch": "main",
     "author": "auto <auto@nil>",
     "noVersionPrefix": false,
     "plugins": [

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -4,4 +4,4 @@ commit = True
 message = [skip ci] Bump version: {current_version} → {new_version}
 tag = False
 
-[bumpversion:file:src/duct/__init__.py]
+[bumpversion:file:src/con_duct/__init__.py]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,9 @@ name: Auto-release on PR merge
 
 on:
   # ATM, this is the closest trigger to a PR merging
-  # push:
-  #   branches:
-  #     - main
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
I followed the instructions for a project that is already released: https://intuit.github.io/auto/docs/welcome/getting-started#make-latest-release

Now, it appears to be configured correctly. 

```
./auto info                

Environment Information:

"auto" version: v11.1.5
"git"  version: v2.45.0
"node" version: v16.16.0

Project Information:

✔ Repository:      con/duct
✔ Author Name:     Austin Macdonald
✔ Author Email:    austin@dartmouth.edu
✔ Current Version: v0.0.1
✔ Latest Release:  v0.0.1

✔ Labels configured on GitHub project 

GitHub Token Information:

✔ Token:            [Token starting with ghp_]
✔ Repo Permission:  admin
✔ User:             asmacdo
✔ API:              
✔ Enabled Scopes:   repo, write:packages
✔ Rate Limit:       2862/5000
```