### PR TITLE
Use None rather than 0 prior to measurement

### DIFF
--- a/src/con_duct/__main__.py
+++ b/src/con_duct/__main__.py
@@ -13,7 +13,7 @@ import subprocess
 import sys
 import threading
 import time
-from typing import Any, IO, Optional, TextIO
+from typing import IO, Any, Optional, TextIO
 from . import __version__
 
 ENV_PREFIXES = ("PBS_", "SLURM_", "OSG")
@@ -406,7 +406,10 @@ class Report:
 
     @cached_property
     def execution_summary_formatted(self) -> str:
-        return {k: "unknown" if v is None else v for k, v in self.execution_summary.items()}
+        human_readable = {
+            k: "unknown" if v is None else v for k, v in self.execution_summary.items()
+        }
+        return self.summary_format.format_map(human_readable)
 
 
 @dataclass
@@ -546,7 +549,9 @@ def monitor_process(
             break
         sample = report.collect_sample()
         # Report averages should be updated prior to sample aggregation
-        if sample is None:  # passthrough has probably finished before sample could be collected
+        if (
+            sample is None
+        ):  # passthrough has probably finished before sample could be collected
             continue
         report.averages.update(sample)
         if report.current_sample is None:

--- a/src/con_duct/__main__.py
+++ b/src/con_duct/__main__.py
@@ -41,12 +41,6 @@ EXECUTION_SUMMARY_FORMAT = (
 )
 
 
-class ExecutionSummary(dict[str, Any]):
-    def __getitem__(self, key: str) -> Optional[str]:
-        value = super().__getitem__(key)
-        return "unknown" if value is None else value
-
-
 def assert_num(*values: Any) -> None:
     for value in values:
         assert isinstance(value, (float, int))

--- a/test/test_report.py
+++ b/test/test_report.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 from datetime import datetime
-import pytest
 from unittest import mock
-from con_duct.__main__ import Averages, EXECUTION_SUMMARY_FORMAT, ProcessStats, Report, Sample
+import pytest
+from con_duct.__main__ import (
+    EXECUTION_SUMMARY_FORMAT,
+    Averages,
+    ProcessStats,
+    Report,
+    Sample,
+)
 
 stat0 = ProcessStats(
     pcpu=0.0, pmem=0, rss=0, vsz=0, timestamp="2024-06-11T10:09:37-04:00"
@@ -103,7 +109,7 @@ def test_averages_three_samples() -> None:
         (0, 0.0, 0, 0.0),
         (2.5, 3.5, 8192, 16384),
         (100.0, 99.9, 65536, 131072),
-    ]
+    ],
 )
 def test_process_stats_green(pcpu: float, pmem: float, rss: int, vsz: int) -> None:
     # Assert does not raise
@@ -124,7 +130,7 @@ def test_process_stats_green(pcpu: float, pmem: float, rss: int, vsz: int) -> No
         (1, 2, "one", 4),
         (1, 2, 3, "value"),
         ("2", "fail", "or", "more"),
-    ]
+    ],
 )
 def test_process_stats_red(pcpu: float, pmem: float, rss: int, vsz: int) -> None:
     with pytest.raises(AssertionError):
@@ -139,14 +145,14 @@ def test_process_stats_red(pcpu: float, pmem: float, rss: int, vsz: int) -> None
 
 @mock.patch("con_duct.__main__.LogPaths")
 @mock.patch("con_duct.__main__.subprocess.Popen")
-def test_print_summary(mock_popen: mock.MagicMock, mock_log_paths: mock.MagicMock) -> None:
+def test_execution_summary_formatted(
+    mock_popen: mock.MagicMock, mock_log_paths: mock.MagicMock
+) -> None:
     mock_log_paths.prefix = "mock_prefix"
-    report = Report('_cmd', [], None, mock_popen, mock_log_paths, EXECUTION_SUMMARY_FORMAT, False)
+    report = Report(
+        "_cmd", [], None, mock_popen, mock_log_paths, EXECUTION_SUMMARY_FORMAT, False
+    )
 
-    with mock.patch("builtins.print", new_callable=mock.MagicMock) as mock_print:
-        report.print_summary()
-
-    mock_print.assert_called_once()
-    assert len(mock_print.call_args_list[0].args) == 1
-    assert "None" not in mock_print.call_args_list[0].args[0]
-    assert "unknown" in mock_print.call_args_list[0].args[0]
+    output = report.execution_summary_formatted
+    assert "None" not in output
+    assert "unknown" in output

--- a/test/test_report.py
+++ b/test/test_report.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 from datetime import datetime
 import pytest
-from con_duct.__main__ import Averages, ProcessStats, Sample
+from unittest import mock
+from con_duct.__main__ import Averages, EXECUTION_SUMMARY_FORMAT, ProcessStats, Report, Sample
 
 stat0 = ProcessStats(
     pcpu=0.0, pmem=0, rss=0, vsz=0, timestamp="2024-06-11T10:09:37-04:00"
@@ -134,3 +135,18 @@ def test_process_stats_red(pcpu: float, pmem: float, rss: int, vsz: int) -> None
             vsz=vsz,
             timestamp=datetime.now().astimezone().isoformat(),
         )
+
+
+@mock.patch("con_duct.__main__.LogPaths")
+@mock.patch("con_duct.__main__.subprocess.Popen")
+def test_print_summary(mock_popen: mock.MagicMock, mock_log_paths: mock.MagicMock) -> None:
+    mock_log_paths.prefix = "mock_prefix"
+    report = Report('_cmd', [], None, mock_popen, mock_log_paths, EXECUTION_SUMMARY_FORMAT, False)
+
+    with mock.patch("builtins.print", new_callable=mock.MagicMock) as mock_print:
+        report.print_summary()
+
+    mock_print.assert_called_once()
+    assert len(mock_print.call_args_list[0].args) == 1
+    assert "None" not in mock_print.call_args_list[0].args[0]
+    assert "unknown" in mock_print.call_args_list[0].args[0]


### PR DESCRIPTION
Fixes https://github.com/con/duct/issues/133

If we have not measured, 0 is incorrect.

We also substitute `unknown` for None when printing for the user