### PR TITLE
RF+ENH: output messages to stderr not stdout + move printing out of "controllers/models"

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ options:
                         Reports Written: {num_reports} )
   --clobber             Replace log files if they already exist. (default:
                         False)
-  -q, --quiet           Suppress duct output. (default: False)
+  -q, --quiet           Suppress duct output (to stderr). (default: False)
   --sample-interval SAMPLE_INTERVAL, --s-i SAMPLE_INTERVAL
                         Interval in seconds between status checks of the
                         running process. Sample interval must be less than or

--- a/src/con_duct/__main__.py
+++ b/src/con_duct/__main__.py
@@ -352,10 +352,6 @@ class Report:
                 json.dumps(self.current_sample.for_json()) + "\n"
             )
 
-    def print_max_values(self) -> None:
-        for pid, maxes in self.max_values.stats.items():
-            print(f"PID {pid} Maximum Values: {asdict(maxes)}")
-
     @cached_property
     def execution_summary(self) -> dict[str, Any]:
         return {

--- a/test/test_execution.py
+++ b/test/test_execution.py
@@ -55,9 +55,9 @@ def test_sanity_red(exit_code: int, temp_output_dir: str) -> None:
         summary_format=EXECUTION_SUMMARY_FORMAT,
         quiet=False,
     )
-    with mock.patch("sys.stdout", new_callable=mock.MagicMock) as mock_stdout:
+    with mock.patch("sys.stderr", new_callable=mock.MagicMock) as mock_stderr:
         assert execute(args) == exit_code
-        call_args = [call.args for call in mock_stdout.write.call_args_list]
+        call_args = [call.args for call in mock_stderr.write.call_args_list]
         assert any(f"Exit Code: {exit_code}" in call_arg[0] for call_arg in call_args)
 
     # We still should execute normally
@@ -179,9 +179,9 @@ def test_outputs_none_quiet(temp_output_dir: str) -> None:
         summary_format="",
         quiet=True,
     )
-    with mock.patch("sys.stdout", new_callable=mock.MagicMock) as mock_stdout:
+    with mock.patch("sys.stderr", new_callable=mock.MagicMock) as mock_stderr:
         assert execute(args) == 0
-        mock_stdout.write.assert_not_called()
+        mock_stderr.write.assert_not_called()
 
 
 def test_exit_before_first_sample(temp_output_dir: str) -> None:


### PR DESCRIPTION
Collection of two commits

- Remove unused/untested print_max_values
-   Most of the tools which operate over some other tool/streams (e.g. pv, datalad
    run, etc) strive to not interfer with stdout so then they could be used
    within pipe constructs.  If such wrapper tool outputs to stdout, then it could
    not be used within a pipe, e.g. in
    
          duct my_amportant_compute | grep "a"
    
    construct.  The same goes for git and git-annex, datalad, etc, unless it is
    explicitly a command intended to display something (e.g. "datalad wtf").
    
    That is why important to not just "print" to stdout but use e.g. stderr which
    is not piped through.  Relates also to issue on logging which should default to
    stderr not stdout.
