### PR TITLE
RF: Add logging, dissolve duct_print (INFO level), add CLI option -l, dissolve --quiet

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ A process wrapper script that monitors the execution of a command.
 >duct --help
 
 usage: duct [-h] [--version] [-p OUTPUT_PREFIX]
-            [--summary-format SUMMARY_FORMAT] [--clobber] [-q]
+            [--summary-format SUMMARY_FORMAT] [--clobber]
+            [-l {CRITICAL,ERROR,WARNING,INFO,DEBUG}]
             [--sample-interval SAMPLE_INTERVAL]
             [--report-interval REPORT_INTERVAL] [-c {all,none,stdout,stderr}]
             [-o {all,none,stdout,stderr}]
@@ -65,7 +66,8 @@ options:
                         Reports Written: {num_reports} )
   --clobber             Replace log files if they already exist. (default:
                         False)
-  -q, --quiet           Suppress duct output (to stderr). (default: False)
+  -l {CRITICAL,ERROR,WARNING,INFO,DEBUG}, --log_level {CRITICAL,ERROR,WARNING,INFO,DEBUG}
+                        Log level from duct operation. (default: DEBUG)
   --sample-interval SAMPLE_INTERVAL, --s-i SAMPLE_INTERVAL
                         Interval in seconds between status checks of the
                         running process. Sample interval must be less than or

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A process wrapper script that monitors the execution of a command.
 
 usage: duct [-h] [--version] [-p OUTPUT_PREFIX]
             [--summary-format SUMMARY_FORMAT] [--clobber]
-            [-l {CRITICAL,ERROR,WARNING,INFO,DEBUG}]
+            [-l {CRITICAL,ERROR,WARNING,INFO,DEBUG}] [-q]
             [--sample-interval SAMPLE_INTERVAL]
             [--report-interval REPORT_INTERVAL] [-c {all,none,stdout,stderr}]
             [-o {all,none,stdout,stderr}]
@@ -67,7 +67,8 @@ options:
   --clobber             Replace log files if they already exist. (default:
                         False)
   -l {CRITICAL,ERROR,WARNING,INFO,DEBUG}, --log_level {CRITICAL,ERROR,WARNING,INFO,DEBUG}
-                        Log level from duct operation. (default: DEBUG)
+                        Log level from duct operation. (default: INFO)
+  -q, --quiet
   --sample-interval SAMPLE_INTERVAL, --s-i SAMPLE_INTERVAL
                         Interval in seconds between status checks of the
                         running process. Sample interval must be less than or

--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ options:
                         False)
   -l {CRITICAL,ERROR,WARNING,INFO,DEBUG}, --log_level {CRITICAL,ERROR,WARNING,INFO,DEBUG}
                         Log level from duct operation. (default: INFO)
-  -q, --quiet
+  -q, --quiet           Suppress duct logging output (to stderr) (default:
+                        False)
   --sample-interval SAMPLE_INTERVAL, --s-i SAMPLE_INTERVAL
                         Interval in seconds between status checks of the
                         running process. Sample interval must be less than or

--- a/src/con_duct/__main__.py
+++ b/src/con_duct/__main__.py
@@ -17,8 +17,6 @@ from typing import IO, Any, Optional, TextIO
 from . import __version__
 
 lgr = logging.getLogger("con-duct")
-# Default log level is DEBUG, but can be overridden by setting DUCT_LOG_LEVEL
-# and later set via CLI argument
 DEFAULT_LOG_LEVEL = os.environ.get("DUCT_LOG_LEVEL", "INFO").upper()
 
 ENV_PREFIXES = ("PBS_", "SLURM_", "OSG")

--- a/src/con_duct/__main__.py
+++ b/src/con_duct/__main__.py
@@ -680,6 +680,7 @@ def execute(args: Arguments) -> int:
 
     Returns exit code of the executed process.
     """
+    lgr.setLevel(args.log_level)
     log_paths = LogPaths.create(args.output_prefix, pid=os.getpid())
     log_paths.prepare_paths(args.clobber, args.capture_outputs)
     stdout, stderr = prepare_outputs(args.capture_outputs, args.outputs, log_paths)

--- a/src/con_duct/__main__.py
+++ b/src/con_duct/__main__.py
@@ -19,7 +19,7 @@ from . import __version__
 lgr = logging.getLogger("con-duct")
 # Default log level is DEBUG, but can be overridden by setting DUCT_LOG_LEVEL
 # and later set via CLI argument
-DEFAULT_LOG_LEVEL = os.environ.get("DUCT_LOG_LEVEL", "DEBUG").upper()
+DEFAULT_LOG_LEVEL = os.environ.get("DUCT_LOG_LEVEL", "INFO").upper()
 
 ENV_PREFIXES = ("PBS_", "SLURM_", "OSG")
 SUFFIXES = {

--- a/src/con_duct/__main__.py
+++ b/src/con_duct/__main__.py
@@ -431,6 +431,7 @@ class Arguments:
     record_types: RecordTypes
     summary_format: str
     log_level: str
+    quiet: bool
 
     def __post_init__(self) -> None:
         if self.report_interval < self.sample_interval:
@@ -488,6 +489,11 @@ class Arguments:
             help="Log level from duct operation.",
         )
         parser.add_argument(
+            "-q",
+            "--quiet",
+            action="store_true",
+        )
+        parser.add_argument(
             "--sample-interval",
             "--s-i",
             type=float,
@@ -541,6 +547,7 @@ class Arguments:
             summary_format=args.summary_format,
             clobber=args.clobber,
             log_level=args.log_level,
+            quiet=args.quiet,
         )
 
 
@@ -681,6 +688,8 @@ def execute(args: Arguments) -> int:
     Returns exit code of the executed process.
     """
     lgr.setLevel(args.log_level)
+    if args.quiet:
+        lgr.disabled = True
     log_paths = LogPaths.create(args.output_prefix, pid=os.getpid())
     log_paths.prepare_paths(args.clobber, args.capture_outputs)
     stdout, stderr = prepare_outputs(args.capture_outputs, args.outputs, log_paths)

--- a/src/con_duct/__main__.py
+++ b/src/con_duct/__main__.py
@@ -490,6 +490,7 @@ class Arguments:
             "-q",
             "--quiet",
             action="store_true",
+            help="Suppress duct logging output (to stderr)",
         )
         parser.add_argument(
             "--sample-interval",

--- a/test/test_execution.py
+++ b/test/test_execution.py
@@ -28,6 +28,7 @@ def test_sanity_green(temp_output_dir: str) -> None:
         clobber=False,
         summary_format="",
         log_level="INFO",
+        quiet=False,
     )
     assert execute(args) == 0
     expected_files = [
@@ -56,6 +57,7 @@ def test_sanity_red(
         clobber=False,
         summary_format=EXECUTION_SUMMARY_FORMAT,
         log_level="INFO",
+        quiet=False,
     )
     caplog.set_level("INFO")
     assert execute(args) == exit_code
@@ -84,6 +86,7 @@ def test_outputs_full(temp_output_dir: str) -> None:
         clobber=False,
         summary_format="",
         log_level="INFO",
+        quiet=False,
     )
     assert execute(args) == 0
     expected_files = [
@@ -108,6 +111,7 @@ def test_outputs_passthrough(temp_output_dir: str) -> None:
         clobber=False,
         summary_format="",
         log_level="INFO",
+        quiet=False,
     )
     assert execute(args) == 0
     expected_files = [SUFFIXES["info"], SUFFIXES["usage"]]
@@ -129,6 +133,7 @@ def test_outputs_capture(temp_output_dir: str) -> None:
         clobber=False,
         summary_format="",
         log_level="INFO",
+        quiet=False,
     )
     assert execute(args) == 0
     # TODO make this work assert mock.call("this is of test of STDOUT\n") not in mock_stdout.write.mock_calls
@@ -155,6 +160,7 @@ def test_outputs_none(temp_output_dir: str) -> None:
         clobber=False,
         summary_format="",
         log_level="INFO",
+        quiet=False,
     )
     assert execute(args) == 0
     # assert mock.call("this is of test of STDOUT\n") not in mock_stdout.write.mock_calls
@@ -179,6 +185,7 @@ def test_outputs_none_quiet(temp_output_dir: str) -> None:
         clobber=False,
         summary_format="",
         log_level="ERROR",
+        quiet=False,
     )
     with mock.patch("sys.stderr", new_callable=mock.MagicMock) as mock_stderr:
         assert execute(args) == 0
@@ -198,6 +205,7 @@ def test_exit_before_first_sample(temp_output_dir: str) -> None:
         clobber=False,
         summary_format="",
         log_level="INFO",
+        quiet=False,
     )
     assert execute(args) == 0
     expected_files = [
@@ -223,6 +231,7 @@ def test_run_less_than_report_interval(temp_output_dir: str) -> None:
         clobber=False,
         summary_format="",
         log_level="INFO",
+        quiet=False,
     )
     assert execute(args) == 0
     # Specifically we need to assert that usage.json gets written anyway.

--- a/test/test_execution.py
+++ b/test/test_execution.py
@@ -27,7 +27,7 @@ def test_sanity_green(temp_output_dir: str) -> None:
         record_types=RecordTypes.ALL,
         clobber=False,
         summary_format="",
-        quiet=False,
+        log_level="INFO",
     )
     assert execute(args) == 0
     expected_files = [
@@ -53,7 +53,7 @@ def test_sanity_red(exit_code: int, temp_output_dir: str) -> None:
         record_types=RecordTypes.ALL,
         clobber=False,
         summary_format=EXECUTION_SUMMARY_FORMAT,
-        quiet=False,
+        log_level="INFO",
     )
     with mock.patch("sys.stderr", new_callable=mock.MagicMock) as mock_stderr:
         assert execute(args) == exit_code
@@ -82,7 +82,7 @@ def test_outputs_full(temp_output_dir: str) -> None:
         record_types=RecordTypes.ALL,
         clobber=False,
         summary_format="",
-        quiet=False,
+        log_level="INFO",
     )
     assert execute(args) == 0
     expected_files = [
@@ -106,7 +106,7 @@ def test_outputs_passthrough(temp_output_dir: str) -> None:
         record_types=RecordTypes.ALL,
         clobber=False,
         summary_format="",
-        quiet=False,
+        log_level="INFO",
     )
     assert execute(args) == 0
     expected_files = [SUFFIXES["info"], SUFFIXES["usage"]]
@@ -127,7 +127,7 @@ def test_outputs_capture(temp_output_dir: str) -> None:
         record_types=RecordTypes.ALL,
         clobber=False,
         summary_format="",
-        quiet=False,
+        log_level="INFO",
     )
     assert execute(args) == 0
     # TODO make this work assert mock.call("this is of test of STDOUT\n") not in mock_stdout.write.mock_calls
@@ -153,7 +153,7 @@ def test_outputs_none(temp_output_dir: str) -> None:
         record_types=RecordTypes.ALL,
         clobber=False,
         summary_format="",
-        quiet=False,
+        log_level="INFO",
     )
     assert execute(args) == 0
     # assert mock.call("this is of test of STDOUT\n") not in mock_stdout.write.mock_calls
@@ -177,7 +177,7 @@ def test_outputs_none_quiet(temp_output_dir: str) -> None:
         record_types=RecordTypes.ALL,
         clobber=False,
         summary_format="",
-        quiet=True,
+        log_level="ERROR",
     )
     with mock.patch("sys.stderr", new_callable=mock.MagicMock) as mock_stderr:
         assert execute(args) == 0
@@ -196,7 +196,7 @@ def test_exit_before_first_sample(temp_output_dir: str) -> None:
         record_types=RecordTypes.ALL,
         clobber=False,
         summary_format="",
-        quiet=False,
+        log_level="INFO",
     )
     assert execute(args) == 0
     expected_files = [
@@ -221,7 +221,7 @@ def test_run_less_than_report_interval(temp_output_dir: str) -> None:
         record_types=RecordTypes.ALL,
         clobber=False,
         summary_format="",
-        quiet=False,
+        log_level="INFO",
     )
     assert execute(args) == 0
     # Specifically we need to assert that usage.json gets written anyway.

--- a/test/test_execution.py
+++ b/test/test_execution.py
@@ -235,14 +235,13 @@ def test_run_less_than_report_interval(temp_output_dir: str) -> None:
     assert_files(temp_output_dir, expected_files, exists=True)
 
 
-def test_execute_unknown_command(temp_output_dir: str) -> None:
+def test_execute_unknown_command(
+    temp_output_dir: str, capsys: pytest.CaptureFixture
+) -> None:
     cmd = "this_command_does_not_exist_123abrakadabra"
     args = Arguments.from_argv([cmd])
-    with mock.patch(
-        "con_duct.__main__.duct_print", new_callable=mock.MagicMock
-    ) as mock_duct_print:
-        assert execute(args) == 127
-        mock_duct_print.assert_called_once_with(f"{cmd}: command not found")
+    assert execute(args) == 127
+    assert f"{cmd}: command not found\n" == capsys.readouterr().err
     expected_files = [
         SUFFIXES["stdout"],
         SUFFIXES["stderr"],

--- a/test/test_validation.py
+++ b/test/test_validation.py
@@ -16,6 +16,7 @@ def test_sample_less_than_report_interval() -> None:
         summary_format="",
         log_level="INFO",
         clobber=False,
+        quiet=False,
     )
     assert args.sample_interval <= args.report_interval
 
@@ -33,6 +34,7 @@ def test_sample_equal_to_report_interval() -> None:
         clobber=False,
         summary_format="",
         log_level="INFO",
+        quiet=False,
     )
     assert args.sample_interval == args.report_interval
 
@@ -51,6 +53,7 @@ def test_sample_equal_greater_than_report_interval() -> None:
             clobber=False,
             summary_format="",
             log_level="INFO",
+            quiet=False,
         )
 
 

--- a/test/test_validation.py
+++ b/test/test_validation.py
@@ -14,7 +14,7 @@ def test_sample_less_than_report_interval() -> None:
         outputs=Outputs.ALL,
         record_types=RecordTypes.SYSTEM_SUMMARY,
         summary_format="",
-        quiet=False,
+        log_level="INFO",
         clobber=False,
     )
     assert args.sample_interval <= args.report_interval
@@ -32,7 +32,7 @@ def test_sample_equal_to_report_interval() -> None:
         record_types=RecordTypes.SYSTEM_SUMMARY,
         clobber=False,
         summary_format="",
-        quiet=False,
+        log_level="INFO",
     )
     assert args.sample_interval == args.report_interval
 
@@ -50,7 +50,7 @@ def test_sample_equal_greater_than_report_interval() -> None:
             record_types=RecordTypes.SYSTEM_SUMMARY,
             clobber=False,
             summary_format="",
-            quiet=False,
+            log_level="INFO",
         )
 
 


### PR DESCRIPTION
When we have logging, and it also goes to stderr, there is really no need for some dedicated "duct_print". Now everything can be controlled with -l and no additional --quiet is needed (good that it was not demoed in https://blog.datalad.org/ post).

I also added a few lgr.debug level statements.

I delayed setup of logging.basicConfig until `main` so it might be more coherent later on with desire to make this whole thing into a reusable Python module

Closes #134 