### PR TITLE
RF+BF: make explicit wall_clock_time separate from elapsed_time

### DIFF
--- a/src/con_duct/__main__.py
+++ b/src/con_duct/__main__.py
@@ -280,7 +280,7 @@ class Report:
         self.summary_format: str = summary_format
         self.clobber = clobber
         # Defaults to be set later
-        self.start_time = None
+        self.start_time: float | None = None
         self.process = process
         self.session_id: int | None = None
         self.gpus: list[dict[str, str]] | None = None
@@ -299,7 +299,7 @@ class Report:
 
     @property
     def elapsed_time(self) -> float:
-        assert self.start_time
+        assert self.start_time is not None
         return time.time() - self.start_time
 
     @property

--- a/src/con_duct/__main__.py
+++ b/src/con_duct/__main__.py
@@ -389,8 +389,7 @@ class Report:
 
     @property
     def execution_summary(self) -> dict[str, Any]:
-        # prepare the base, but enrich if we did get process
-        # running
+        # prepare the base, but enrich if we did get process running
         return {
             "exit_code": self.process.returncode if self.process else None,
             "command": self.command,

--- a/src/con_duct/__main__.py
+++ b/src/con_duct/__main__.py
@@ -718,7 +718,7 @@ def execute(args: Arguments) -> int:
 
     full_command = " ".join([str(args.command)] + args.command_args)
     files_to_close = [stdout_file, stdout, stderr_file, stderr]
-    
+
     report = Report(
         args.command,
         args.command_args,

--- a/src/con_duct/__main__.py
+++ b/src/con_duct/__main__.py
@@ -4,7 +4,6 @@ from collections.abc import Iterable, Iterator
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from enum import Enum
-from functools import cached_property
 import json
 import logging
 import math
@@ -388,7 +387,7 @@ class Report:
                 json.dumps(self.current_sample.for_json()) + "\n"
             )
 
-    @cached_property
+    @property
     def execution_summary(self) -> dict[str, Any]:
         # prepare the base, but enrich if we did get process
         # running
@@ -423,7 +422,7 @@ class Report:
             }
         )
 
-    @cached_property
+    @property
     def execution_summary_formatted(self) -> str:
         human_readable = {
             k: "unknown" if v is None else v for k, v in self.execution_summary.items()

--- a/test/test_report.py
+++ b/test/test_report.py
@@ -149,10 +149,14 @@ def test_execution_summary_formatted(
     mock_popen: mock.MagicMock, mock_log_paths: mock.MagicMock
 ) -> None:
     mock_log_paths.prefix = "mock_prefix"
-    report = Report(
-        "_cmd", [], None, mock_popen, mock_log_paths, EXECUTION_SUMMARY_FORMAT, False
-    )
+    report = Report("_cmd", [], None, EXECUTION_SUMMARY_FORMAT, clobber=False)
+    # It should not crash and it would render even where no wallclock time yet
+    assert "wall clock time: nan" in report.execution_summary_formatted.lower()
 
+    # Test with process
+    report.process = mock_popen
     output = report.execution_summary_formatted
     assert "None" not in output
     assert "unknown" in output
+    # Process did not finish, we didn't set start_time, so remains nan but there
+    assert "wall clock time: nan" in report.execution_summary_formatted.lower()

--- a/test/test_report.py
+++ b/test/test_report.py
@@ -149,7 +149,7 @@ def test_execution_summary_formatted(
     mock_popen: mock.MagicMock, mock_log_paths: mock.MagicMock
 ) -> None:
     mock_log_paths.prefix = "mock_prefix"
-    report = Report("_cmd", [], None, EXECUTION_SUMMARY_FORMAT, clobber=False)
+    report = Report("_cmd", [], mock_log_paths, EXECUTION_SUMMARY_FORMAT, clobber=False)
     # It should not crash and it would render even where no wallclock time yet
     assert "wall clock time: nan" in report.execution_summary_formatted.lower()
 


### PR DESCRIPTION
Also moved stop_time as close to .wait as possible.  Now with such changes we get some reasonable precision in reported wall clock time:

    ❯ duct sleep 1 2>&1 | grep Wall
    Wall Clock Time: 1.002 sec
    ❯ duct sleep 0.1 2>&1 | grep Wall
    Wall Clock Time: 0.102 sec

- Closes #127