### PR TITLE
RF+BF: update maxes on each sample, more logging during monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ options:
                         False)
   -l {CRITICAL,ERROR,WARNING,INFO,DEBUG}, --log_level {CRITICAL,ERROR,WARNING,INFO,DEBUG}
                         Log level from duct operation. (default: INFO)
-  -q, --quiet           Suppress duct logging output (to stderr) (default:
+  -q, --quiet           Disable duct logging output (to stderr) (default:
                         False)
   --sample-interval SAMPLE_INTERVAL, --s-i SAMPLE_INTERVAL
                         Interval in seconds between status checks of the

--- a/src/con_duct/__main__.py
+++ b/src/con_duct/__main__.py
@@ -174,7 +174,6 @@ class Averages:
     def update(self: Averages, other: Sample) -> None:
         assert_num(other.total_rss, other.total_vsz, other.total_pmem, other.total_pcpu)
         if not self.num_samples:
-            # how do we hit it???
             self.num_samples += 1
             self.rss = other.total_rss
             self.vsz = other.total_vsz
@@ -325,7 +324,7 @@ class Report:
         self.system_info = SystemInfo(
             uid=uid, memory_total=memory_total, cpu_total=cpu_total
         )
-        # GPU information.
+        # GPU information
         if shutil.which("nvidia-smi"):
             lgr.debug("Checking NVIDIA GPU using nvidia-smi")
             try:

--- a/src/con_duct/__main__.py
+++ b/src/con_duct/__main__.py
@@ -452,7 +452,9 @@ class Arguments:
             )
 
     @classmethod
-    def from_argv(cls, cli_args: Optional[list[str]] = None) -> Arguments:
+    def from_argv(
+        cls, cli_args: Optional[list[str]] = None, **cli_kwargs: Any
+    ) -> Arguments:
         parser = argparse.ArgumentParser(
             description="Gathers metrics on a command and all its child processes.",
             formatter_class=argparse.ArgumentDefaultsHelpFormatter,
@@ -546,7 +548,10 @@ class Arguments:
             type=RecordTypes,
             help="Record system-summary, processes-samples, or all",
         )
-        args = parser.parse_args(args=cli_args)
+        args = parser.parse_args(
+            args=cli_args,
+            namespace=cli_kwargs and argparse.Namespace(**cli_kwargs) or None,
+        )
         return cls(
             command=args.command,
             command_args=args.command_args,

--- a/src/con_duct/__main__.py
+++ b/src/con_duct/__main__.py
@@ -505,7 +505,7 @@ class Arguments:
             "-q",
             "--quiet",
             action="store_true",
-            help="Suppress duct logging output (to stderr)",
+            help="Disable duct logging output (to stderr)",
         )
         parser.add_argument(
             "--sample-interval",

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,6 +1,25 @@
 import os
 from pathlib import Path
+from typing import Generator
 import pytest
+
+
+@pytest.fixture(scope="session", autouse=True)
+def set_test_config() -> Generator:
+    # set DUCT_SAMPLE_INTERVAL and DUCT_REPORT_INTERVAL to small values
+    # to speed up testing etc. Those could be overridden by a specific
+    # invocation of .from_args() in a test.
+    orig_environ = os.environ.copy()
+    os.environ["DUCT_SAMPLE_INTERVAL"] = "0.01"
+    os.environ["DUCT_REPORT_INTERVAL"] = "0.1"
+    yield
+    # May be not even needed, but should not hurt to cleanup.
+    # it is not just a dict, so let's explicitly reset it
+    for k, v in os.environ.items():
+        if k in orig_environ:
+            os.environ[k] = v
+        else:
+            del os.environ[k]
 
 
 @pytest.fixture

--- a/test/test_execution.py
+++ b/test/test_execution.py
@@ -14,6 +14,17 @@ from con_duct.__main__ import (
 
 TEST_SCRIPT = str(Path(__file__).with_name("data") / "test_script.py")
 
+expected_files = [
+    SUFFIXES["stdout"],
+    SUFFIXES["stderr"],
+    SUFFIXES["info"],
+    SUFFIXES["usage"],
+]
+
+
+def assert_expected_files(temp_output_dir: str, exists: bool = True) -> None:
+    assert_files(temp_output_dir, expected_files, exists=exists)
+
 
 def test_sanity_green(temp_output_dir: str) -> None:
     args = Arguments(
@@ -31,13 +42,8 @@ def test_sanity_green(temp_output_dir: str) -> None:
         quiet=False,
     )
     assert execute(args) == 0
-    expected_files = [
-        SUFFIXES["stdout"],
-        SUFFIXES["stderr"],
-        SUFFIXES["info"],
-        SUFFIXES["usage"],
-    ]
-    assert_files(temp_output_dir, expected_files, exists=True)
+
+    assert_expected_files(temp_output_dir)
     # TODO check usagefile empty
 
 
@@ -64,13 +70,7 @@ def test_sanity_red(
     assert f"Exit Code: {exit_code}" in caplog.records[-1].message
 
     # We still should execute normally
-    expected_files = [
-        SUFFIXES["stdout"],
-        SUFFIXES["stderr"],
-        SUFFIXES["info"],
-        SUFFIXES["usage"],
-    ]
-    assert_files(temp_output_dir, expected_files, exists=True)
+    assert_expected_files(temp_output_dir)
 
 
 def test_outputs_full(temp_output_dir: str) -> None:
@@ -89,13 +89,7 @@ def test_outputs_full(temp_output_dir: str) -> None:
         quiet=False,
     )
     assert execute(args) == 0
-    expected_files = [
-        SUFFIXES["stdout"],
-        SUFFIXES["stderr"],
-        SUFFIXES["info"],
-        SUFFIXES["usage"],
-    ]
-    assert_files(temp_output_dir, expected_files, exists=True)
+    assert_expected_files(temp_output_dir)
 
 
 def test_outputs_passthrough(temp_output_dir: str) -> None:
@@ -138,13 +132,7 @@ def test_outputs_capture(temp_output_dir: str) -> None:
     assert execute(args) == 0
     # TODO make this work assert mock.call("this is of test of STDOUT\n") not in mock_stdout.write.mock_calls
 
-    expected_files = [
-        SUFFIXES["stdout"],
-        SUFFIXES["stderr"],
-        SUFFIXES["info"],
-        SUFFIXES["usage"],
-    ]
-    assert_files(temp_output_dir, expected_files, exists=True)
+    assert_expected_files(temp_output_dir)
 
 
 def test_outputs_none(temp_output_dir: str) -> None:
@@ -208,13 +196,7 @@ def test_exit_before_first_sample(temp_output_dir: str) -> None:
         quiet=False,
     )
     assert execute(args) == 0
-    expected_files = [
-        SUFFIXES["stdout"],
-        SUFFIXES["stderr"],
-        SUFFIXES["info"],
-        SUFFIXES["usage"],
-    ]
-    assert_files(temp_output_dir, expected_files, exists=True)
+    assert_expected_files(temp_output_dir)
     # TODO check usagefile
 
 
@@ -235,13 +217,7 @@ def test_run_less_than_report_interval(temp_output_dir: str) -> None:
     )
     assert execute(args) == 0
     # Specifically we need to assert that usage.json gets written anyway.
-    expected_files = [
-        SUFFIXES["stdout"],
-        SUFFIXES["stderr"],
-        SUFFIXES["usage"],
-        SUFFIXES["info"],
-    ]
-    assert_files(temp_output_dir, expected_files, exists=True)
+    assert_expected_files(temp_output_dir)
 
 
 def test_execute_unknown_command(
@@ -251,10 +227,4 @@ def test_execute_unknown_command(
     args = Arguments.from_argv([cmd])
     assert execute(args) == 127
     assert f"{cmd}: command not found\n" == capsys.readouterr().err
-    expected_files = [
-        SUFFIXES["stdout"],
-        SUFFIXES["stderr"],
-        SUFFIXES["info"],
-        SUFFIXES["usage"],
-    ]
-    assert_files(temp_output_dir, expected_files, exists=False)
+    assert_expected_files(temp_output_dir, exists=False)

--- a/test/test_validation.py
+++ b/test/test_validation.py
@@ -1,59 +1,32 @@
 import argparse
 import pytest
-from con_duct.__main__ import Arguments, Outputs, RecordTypes, assert_num
+from con_duct.__main__ import Arguments, assert_num
 
 
 def test_sample_less_than_report_interval() -> None:
-    args = Arguments(
-        command="fake",
-        command_args=[],
-        output_prefix="fake",
+    args = Arguments.from_argv(
+        ["fake"],
         sample_interval=0.01,
         report_interval=0.1,
-        capture_outputs=Outputs.NONE,
-        outputs=Outputs.ALL,
-        record_types=RecordTypes.SYSTEM_SUMMARY,
-        summary_format="",
-        log_level="INFO",
-        clobber=False,
-        quiet=False,
     )
     assert args.sample_interval <= args.report_interval
 
 
 def test_sample_equal_to_report_interval() -> None:
-    args = Arguments(
-        command="fake",
-        command_args=[],
-        output_prefix="fake",
+    args = Arguments.from_argv(
+        ["fake"],
         sample_interval=0.1,
         report_interval=0.1,
-        capture_outputs=Outputs.NONE,
-        outputs=Outputs.ALL,
-        record_types=RecordTypes.SYSTEM_SUMMARY,
-        clobber=False,
-        summary_format="",
-        log_level="INFO",
-        quiet=False,
     )
     assert args.sample_interval == args.report_interval
 
 
 def test_sample_equal_greater_than_report_interval() -> None:
     with pytest.raises(argparse.ArgumentError):
-        Arguments(
-            command="fake",
-            command_args=[],
-            output_prefix="fake",
+        Arguments.from_argv(
+            ["fake"],
             sample_interval=1.0,
             report_interval=0.1,
-            capture_outputs=Outputs.NONE,
-            outputs=Outputs.ALL,
-            record_types=RecordTypes.SYSTEM_SUMMARY,
-            clobber=False,
-            summary_format="",
-            log_level="INFO",
-            quiet=False,
         )
 
 


### PR DESCRIPTION
We figured out occasional "slow down" -- it is due to nvidia-smi invocation
    during collection of summary. Relevant now issue:
 
   - https://github.com/con/duct/issues/145
    
 We added more logging in the monitoring loop so we would know when/why we
 are leaving it.
    
 We also added explicit 2nd break out from the loop if process is gone before
 we manage to ps.

Sits on top of

- #143 