### PR TITLE
Do not use setsid directly, use dedicated start_new_session

### DIFF
--- a/src/con_duct/__main__.py
+++ b/src/con_duct/__main__.py
@@ -771,7 +771,7 @@ def execute(args: Arguments) -> int:
             [str(args.command)] + args.command_args,
             stdout=stdout_file,
             stderr=stderr_file,
-            preexec_fn=os.setsid,
+            start_new_session=True,
         )
     except FileNotFoundError:
         # We failed to execute due to file not found in PATH

--- a/test/test_execution.py
+++ b/test/test_execution.py
@@ -28,7 +28,7 @@ def test_sanity_green(temp_output_dir: str) -> None:
     )
     t0 = time()
     assert execute(args) == 0
-    assert time() - t0 < 0.2  # we should not wait for a sample or report interval
+    assert time() - t0 < 0.4  # we should not wait for a sample or report interval
     assert_expected_files(temp_output_dir)
     # TODO check usagefile empty
 


### PR DESCRIPTION
Just ran into
https://stackoverflow.com/questions/42257512/difference-between-subprocess-popen-preexec-fn-and-start-new-session-in-python which points to python docs at
https://docs.python.org/3.4/library/subprocess.html?highlight=subprocess#popen-constructor

    Warning The preexec_fn parameter is not safe to use in the presence
    of threads in your application. The child process could deadlock before
    exec is called. If you must use it, keep it trivial! Minimize the number of
    libraries you call into.

    Note If you need to modify the environment for the child use the env
    parameter rather than doing it in a preexec_fn. The start_new_session
    parameter can take the place of a previously common use of preexec_fn to
    call os.setsid() in the child.

So smells like we better use this dedicated option added in 3.2 .

But may be it was considered and argued against @asmacdo and doesn't work as desired 

(there is a separate discussion on possibly using group not session ids in https://github.com/con/duct/issues/82)