### PR TITLE
Argparse abbreviation affects and breaks cmd args

### DIFF
--- a/src/con_duct/__main__.py
+++ b/src/con_duct/__main__.py
@@ -503,6 +503,7 @@ class Arguments:
         cls, cli_args: Optional[list[str]] = None, **cli_kwargs: Any
     ) -> Arguments:
         parser = argparse.ArgumentParser(
+            allow_abbrev=False,
             description=ABOUT_DUCT,
             formatter_class=CustomHelpFormatter,
         )

--- a/test/test_arg_parsing.py
+++ b/test/test_arg_parsing.py
@@ -49,6 +49,7 @@ def test_abreviation_disabled() -> None:
     """
     try:
         subprocess.check_output(["duct", "ps", "--output"], stderr=subprocess.STDOUT)
+        raise AssertionError("Invocation of 'ps' should have failed")
     except subprocess.CalledProcessError as e:
         assert e.returncode == 1
         assert "duct: error: ambiguous option: --output could match" not in str(

--- a/test/test_arg_parsing.py
+++ b/test/test_arg_parsing.py
@@ -40,3 +40,18 @@ def test_duct_missing_cmd() -> None:
         assert "duct: error: the following arguments are required: command" in str(
             e.stdout
         )
+
+
+def test_abreviation_disabled() -> None:
+    """
+    If abbreviation is enabled, options passed to command (not duct) are still
+    filtered through the argparse and causes problems.
+    """
+    try:
+        subprocess.check_output(["duct", "ps", "--output"], stderr=subprocess.STDOUT)
+    except subprocess.CalledProcessError as e:
+        assert e.returncode == 1
+        assert "duct: error: ambiguous option: --output could match" not in str(
+            e.stdout
+        )
+        assert "ps [options]" in str(e.stdout)


### PR DESCRIPTION
Builds on https://github.com/con/duct/pull/166 (merge that first)

This came up while using duct with `mriqc` 

```
duct -p ../duct_out/Z_ --clobber datalad containers-run \
        -n bids-mriqc \
        --input sourcedata \
        --output . \
        '{inputs}' '{outputs}' participant --participant-label 02 -w workdir
```

The `--output` option caused the command to fail:
 `duct: error: ambiguous option: --output could match --output-prefix, --outputs`
