### PR TITLE
Add output files and schema version to info.json

### DIFF
--- a/src/con_duct/__init__.py
+++ b/src/con_duct/__init__.py
@@ -1,1 +1,2 @@
 __version__ = "0.2.0"
+__schema_version__ = "0.1.0"

--- a/src/con_duct/__main__.py
+++ b/src/con_duct/__main__.py
@@ -16,7 +16,7 @@ import textwrap
 import threading
 import time
 from typing import IO, Any, Optional, TextIO
-from . import __version__
+from . import __schema_version__, __version__
 
 lgr = logging.getLogger("con-duct")
 DEFAULT_LOG_LEVEL = os.environ.get("DUCT_LOG_LEVEL", "INFO").upper()
@@ -193,6 +193,14 @@ class LogPaths:
                 continue
             # usage and info should always be created
             open(path, "w").close()
+
+    def for_json(self) -> dict[str, Any]:
+        return {
+            "stdout": self.stdout,
+            "stderr": self.stderr,
+            "usage": {"schema_version": __schema_version__, "path": self.usage},
+            "info": self.info,
+        }
 
 
 @dataclass
@@ -465,6 +473,7 @@ class Report:
                 "gpu": self.gpus,
                 "duct_version": __version__,
                 "execution_summary": self.execution_summary,
+                "output_paths": self.log_paths.for_json(),
             }
         )
 

--- a/src/con_duct/__main__.py
+++ b/src/con_duct/__main__.py
@@ -194,14 +194,6 @@ class LogPaths:
             # usage and info should always be created
             open(path, "w").close()
 
-    def for_json(self) -> dict[str, Any]:
-        return {
-            "stdout": self.stdout,
-            "stderr": self.stderr,
-            "usage": {"schema_version": __schema_version__, "path": self.usage},
-            "info": self.info,
-        }
-
 
 @dataclass
 class Averages:
@@ -472,8 +464,9 @@ class Report:
                 "env": self.env,
                 "gpu": self.gpus,
                 "duct_version": __version__,
+                "schema_version": __schema_version__,
                 "execution_summary": self.execution_summary,
-                "output_paths": self.log_paths.for_json(),
+                "output_paths": asdict(self.log_paths),
             }
         )
 


### PR DESCRIPTION
Fixes: https://github.com/con/duct/issues/165
Replaces: https://github.com/con/duct/pull/123

`info.json`
```json
{
  "command": "ls",
  "system": {
    "uid": "austin",
    "memory_total": 33336778752,
    "cpu_total": 20,
    "hostname": "fancy"
  },
  "env": {},
  "gpu": null,
  "duct_version": "0.2.0",
  "execution_summary": {
    "exit_code": 0,
    "command": "ls",
    "logs_prefix": "Z_",
    "wall_clock_time": 0.0021119117736816406,
    "peak_rss": null,
    "average_rss": null,
    "peak_vsz": null,
    "average_vsz": null,
    "peak_pmem": null,
    "average_pmem": null,
    "peak_pcpu": null,
    "average_pcpu": null,
    "num_samples": 0,
    "num_reports": 0
  },
  "output_paths": {
    "stdout": "Z_stdout",
    "stderr": "Z_stderr",
    "usage": {
      "schema_version": "0.1.0",
      "path": "Z_usage.json"
    },
    "info": "Z_info.json"
  }
}
