### PR TITLE
Round before formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ options:
                         Output template to use when printing the summary
                         following execution. (default: Exit Code: {exit_code}
                         Command: {command} Log files location: {logs_prefix}
-                        Wall Clock Time: {wall_clock_time:.3f} sec Memory Peak
+                        Wall Clock Time: {wall_clock_time} sec Memory Peak
                         Usage (RSS): {peak_rss} bytes Memory Average Usage
                         (RSS): {average_rss} bytes Virtual Memory Peak Usage
                         (VSZ): {peak_vsz} bytes Virtual Memory Average Usage

--- a/src/con_duct/__main__.py
+++ b/src/con_duct/__main__.py
@@ -33,7 +33,7 @@ EXECUTION_SUMMARY_FORMAT = (
     "Exit Code: {exit_code}\n"
     "Command: {command}\n"
     "Log files location: {logs_prefix}\n"
-    "Wall Clock Time: {wall_clock_time:.3f} sec\n"
+    "Wall Clock Time: {wall_clock_time} sec\n"
     "Memory Peak Usage (RSS): {peak_rss} bytes\n"
     "Memory Average Usage (RSS): {average_rss} bytes\n"
     "Virtual Memory Peak Usage (VSZ): {peak_vsz} bytes\n"
@@ -494,10 +494,18 @@ class Report:
 
     @property
     def execution_summary_formatted(self) -> str:
-        human_readable = {
+        unknowned = {
             k: "unknown" if v is None else v for k, v in self.execution_summary.items()
         }
-        return self.summary_format.format_map(human_readable)
+
+        rounded = {}
+        for k, v in unknowned.items():
+            if isinstance(v, float):
+                rounded[k] = round(v, 2)
+            else:
+                rounded[k] = v
+
+        return self.summary_format.format_map(rounded)
 
 
 @dataclass


### PR DESCRIPTION
If we don't do the rounding prior to formatting, the summary_format (being a format string, not an f-string) is not smart enough to handle floats OR None (or str 'unknown'). So instead we need to handle that first.

Fixes: https://github.com/con/duct/issues/172
Fixes: https://github.com/con/duct/issues/171