### PR TITLE
Add ps stat counter

### DIFF
--- a/src/con_duct/__main__.py
+++ b/src/con_duct/__main__.py
@@ -1048,7 +1048,6 @@ def execute(args: Arguments) -> int:
 
     # If we have any extra samples that haven't been written yet, do it now
     if report.current_sample is not None:
-        report.full_run_stats = report.full_run_stats.aggregate(report.current_sample)
         report.write_subreport()
 
     report.process = process

--- a/src/con_duct/__main__.py
+++ b/src/con_duct/__main__.py
@@ -152,7 +152,7 @@ class ProcessStats:
                 cmd = other.cmd
             lgr.debug(f"using {self.cmd}.")
 
-        new_counter = Counter()
+        new_counter: Counter = Counter()
         new_counter.update(self.stat)
         new_counter.update(other.stat)
         return ProcessStats(

--- a/src/con_duct/__main__.py
+++ b/src/con_duct/__main__.py
@@ -135,7 +135,8 @@ class ProcessStats:
     vsz: int  # Virtual Memory size in Bytes
     timestamp: str
     etime: str
-    cmd: str
+    stat: str
+    cmd: list[str]
 
     def aggregate(self, other: ProcessStats) -> ProcessStats:
         cmd = self.cmd
@@ -156,6 +157,7 @@ class ProcessStats:
             vsz=max(self.vsz, other.vsz),
             timestamp=max(self.timestamp, other.timestamp),
             etime=other.etime,  # For the aggregate always take the latest
+            stat=self.stat + other.stat,
             cmd=cmd,
         )
 
@@ -440,8 +442,8 @@ class Report:
             )
             for line in output.splitlines()[1:]:
                 if line:
-                    pid, pcpu, pmem, rss_kib, vsz_kib, etime, cmd = line.split(
-                        maxsplit=6,
+                    pid, pcpu, pmem, rss_kib, vsz_kib, etime, stat, cmd = line.split(
+                        maxsplit=7,
                     )
                     sample.add_pid(
                         int(pid),
@@ -452,6 +454,7 @@ class Report:
                             vsz=int(vsz_kib) * 1024,
                             timestamp=datetime.now().astimezone().isoformat(),
                             etime=etime,
+                            stat=[stat],
                             cmd=cmd,
                         ),
                     )

--- a/src/con_duct/__main__.py
+++ b/src/con_duct/__main__.py
@@ -152,7 +152,9 @@ class ProcessStats:
                 cmd = other.cmd
             lgr.debug(f"using {self.cmd}.")
 
-        self.stat.update(other.stat)
+        new_counter = Counter()
+        new_counter.update(self.stat)
+        new_counter.update(other.stat)
         return ProcessStats(
             pcpu=max(self.pcpu, other.pcpu),
             pmem=max(self.pmem, other.pmem),
@@ -160,7 +162,7 @@ class ProcessStats:
             vsz=max(self.vsz, other.vsz),
             timestamp=max(self.timestamp, other.timestamp),
             etime=other.etime,  # For the aggregate always take the latest
-            stat=self.stat,
+            stat=new_counter,
             cmd=cmd,
         )
 
@@ -294,7 +296,6 @@ class Sample:
         self.total_pcpu = (self.total_pcpu or 0.0) + stats.pcpu
         self.stats[pid] = stats
         self.timestamp = max(self.timestamp, stats.timestamp)
-        self.stats[pid] = stats
 
     def aggregate(self: Sample, other: Sample) -> Sample:
         output = Sample()

--- a/src/con_duct/__main__.py
+++ b/src/con_duct/__main__.py
@@ -137,7 +137,7 @@ class ProcessStats:
     timestamp: str
     etime: str
     stat: Counter
-    cmd: list[str]
+    cmd: str
 
     def aggregate(self, other: ProcessStats) -> ProcessStats:
         cmd = self.cmd
@@ -164,7 +164,7 @@ class ProcessStats:
             cmd=cmd,
         )
 
-    def for_json(self) -> None:
+    def for_json(self) -> dict:
         ret = asdict(self)
         ret["stat"] = dict(self.stat)
         return ret

--- a/test/test_aggregation.py
+++ b/test/test_aggregation.py
@@ -1,3 +1,4 @@
+from collections import Counter
 from typing import cast
 from unittest import mock
 import pytest
@@ -11,7 +12,7 @@ stat0 = ProcessStats(
     timestamp="2024-06-11T10:09:37-04:00",
     etime="00:00",
     cmd="cmd 0",
-    stat="stat0",
+    stat=Counter(["stat0"]),
 )
 
 stat1 = ProcessStats(
@@ -22,7 +23,7 @@ stat1 = ProcessStats(
     timestamp="2024-06-11T10:13:23-04:00",
     etime="00:02",
     cmd="cmd 1",
-    stat="stat1",
+    stat=Counter(["stat1"]),
 )
 
 stat2 = ProcessStats(
@@ -33,7 +34,7 @@ stat2 = ProcessStats(
     timestamp="2024-06-11T10:13:23-04:00",
     etime="00:02",
     cmd="cmd 2",
-    stat="stat2",
+    stat=Counter(["stat2"]),
 )
 
 stat100 = ProcessStats(
@@ -44,6 +45,7 @@ stat100 = ProcessStats(
     timestamp="2024-06-11T10:13:23-04:00",
     etime="00:02",
     cmd="cmd 100",
+    stat=Counter(["stat100"]),
 )
 stat_big = ProcessStats(
     pcpu=20000.0,
@@ -53,7 +55,7 @@ stat_big = ProcessStats(
     timestamp="2024-06-11T10:13:23-04:00",
     etime="00:02",
     cmd="cmd 2",
-    stat="stat2",
+    stat=Counter(["statbig"]),
 )
 
 

--- a/test/test_aggregation.py
+++ b/test/test_aggregation.py
@@ -1,4 +1,5 @@
 from collections import Counter
+from copy import deepcopy
 from typing import cast
 from unittest import mock
 import pytest
@@ -62,7 +63,7 @@ stat_big = ProcessStats(
 @mock.patch("con_duct.__main__.LogPaths")
 def test_aggregation_num_samples_increment(mock_log_paths: mock.MagicMock) -> None:
     ex0 = Sample()
-    ex0.add_pid(1, stat1)
+    ex0.add_pid(1, deepcopy(stat1))
     mock_log_paths.prefix = "mock_prefix"
     report = Report("_cmd", [], mock_log_paths, EXECUTION_SUMMARY_FORMAT, clobber=False)
     assert report.current_sample is None
@@ -85,9 +86,9 @@ def test_aggregation_num_samples_increment(mock_log_paths: mock.MagicMock) -> No
 @mock.patch("con_duct.__main__.LogPaths")
 def test_aggregation_single_sample_sanity(mock_log_paths: mock.MagicMock) -> None:
     ex0 = Sample()
-    ex0.add_pid(0, stat0)
-    ex0.add_pid(1, stat1)
-    ex0.add_pid(2, stat2)
+    ex0.add_pid(0, deepcopy(stat0))
+    ex0.add_pid(1, deepcopy(stat1))
+    ex0.add_pid(2, deepcopy(stat2))
     mock_log_paths.prefix = "mock_prefix"
     report = Report("_cmd", [], mock_log_paths, EXECUTION_SUMMARY_FORMAT, clobber=False)
     assert report.current_sample is None
@@ -121,7 +122,7 @@ def test_aggregation_single_stat_multiple_samples_sanity(
     mock_log_paths: mock.MagicMock, stat: ProcessStats
 ) -> None:
     ex0 = Sample()
-    ex0.add_pid(1, stat)
+    ex0.add_pid(1, deepcopy(stat))
     mock_log_paths.prefix = "mock_prefix"
     report = Report("_cmd", [], mock_log_paths, EXECUTION_SUMMARY_FORMAT, clobber=False)
     assert report.current_sample is None
@@ -163,11 +164,11 @@ def test_aggregation_single_stat_multiple_samples_sanity(
 @mock.patch("con_duct.__main__.LogPaths")
 def test_aggregation_averages(mock_log_paths: mock.MagicMock) -> None:
     sample0 = Sample()
-    sample0.add_pid(1, stat0)
+    sample0.add_pid(1, deepcopy(stat0))
     sample1 = Sample()
-    sample1.add_pid(1, stat1)
+    sample1.add_pid(1, deepcopy(stat1))
     sample2 = Sample()
-    sample2.add_pid(1, stat2)
+    sample2.add_pid(1, deepcopy(stat2))
     mock_log_paths.prefix = "mock_prefix"
     report = Report("_cmd", [], mock_log_paths, EXECUTION_SUMMARY_FORMAT, clobber=False)
     assert report.current_sample is None
@@ -232,11 +233,11 @@ def test_aggregation_current_ave_diverges_from_total_ave(
     mock_log_paths: mock.MagicMock,
 ) -> None:
     sample0 = Sample()
-    sample0.add_pid(1, stat0)
+    sample0.add_pid(1, deepcopy(stat0))
     sample1 = Sample()
-    sample1.add_pid(1, stat1)
+    sample1.add_pid(1, deepcopy(stat1))
     sample2 = Sample()
-    sample2.add_pid(1, stat2)
+    sample2.add_pid(1, deepcopy(stat2))
     mock_log_paths.prefix = "mock_prefix"
     report = Report("_cmd", [], mock_log_paths, EXECUTION_SUMMARY_FORMAT, clobber=False)
     assert report.current_sample is None
@@ -299,7 +300,7 @@ def test_aggregation_many_samples(
     mock_log_paths: mock.MagicMock, stat: ProcessStats
 ) -> None:
     sample1 = Sample()
-    sample1.add_pid(1, stat)
+    sample1.add_pid(1, deepcopy(stat))
     mock_log_paths.prefix = "mock_prefix"
     report = Report("_cmd", [], mock_log_paths, EXECUTION_SUMMARY_FORMAT, clobber=False)
     assert report.current_sample is None
@@ -316,7 +317,7 @@ def test_aggregation_many_samples(
 
     # Add a stat that is not 0 and check that the average is still correct
     sample2 = Sample()
-    sample2.add_pid(1, stat2)
+    sample2.add_pid(1, deepcopy(stat2))
     report.update_from_sample(sample2)
     assert report.full_run_stats.averages.num_samples == 101
     assert report.full_run_stats.averages.rss == (stat.rss * 100 + stat2.rss) / 101.0
@@ -342,11 +343,11 @@ def test_aggregation_no_false_peak(mock_log_paths: mock.MagicMock) -> None:
     sample2 = Sample()
     mock_log_paths.prefix = "mock_prefix"
     report = Report("_cmd", [], mock_log_paths, EXECUTION_SUMMARY_FORMAT, clobber=False)
-    sample1.add_pid(1, stat100)
-    sample1.add_pid(2, stat0)
+    sample1.add_pid(1, deepcopy(stat100))
+    sample1.add_pid(2, deepcopy(stat0))
     report.update_from_sample(sample1)
-    sample2.add_pid(1, stat0)
-    sample2.add_pid(2, stat100)
+    sample2.add_pid(1, deepcopy(stat0))
+    sample2.add_pid(2, deepcopy(stat100))
     report.update_from_sample(sample2)
     assert report.current_sample is not None
     assert report.current_sample.total_pcpu == 100

--- a/test/test_aggregation.py
+++ b/test/test_aggregation.py
@@ -11,6 +11,7 @@ stat0 = ProcessStats(
     timestamp="2024-06-11T10:09:37-04:00",
     etime="00:00",
     cmd="cmd 0",
+    stat="stat0",
 )
 
 stat1 = ProcessStats(
@@ -21,6 +22,7 @@ stat1 = ProcessStats(
     timestamp="2024-06-11T10:13:23-04:00",
     etime="00:02",
     cmd="cmd 1",
+    stat="stat1",
 )
 
 stat2 = ProcessStats(
@@ -31,6 +33,7 @@ stat2 = ProcessStats(
     timestamp="2024-06-11T10:13:23-04:00",
     etime="00:02",
     cmd="cmd 2",
+    stat="stat2",
 )
 
 stat100 = ProcessStats(
@@ -50,6 +53,7 @@ stat_big = ProcessStats(
     timestamp="2024-06-11T10:13:23-04:00",
     etime="00:02",
     cmd="cmd 2",
+    stat="stat2",
 )
 
 

--- a/test/test_aggregation.py
+++ b/test/test_aggregation.py
@@ -310,7 +310,11 @@ def test_aggregation_many_samples(
     # Ensure nothing strange happens after many updates
     for _ in range(100):
         report.update_from_sample(sample1)
-    # TODO Python 3.10+ added Counter.totals()
+
+    report.current_sample = cast(
+        Sample, report.current_sample
+    )  # So mypy is convcinced it is not None
+    assert report.current_sample is not None
     # Assert that there is exactly 1 ProcessStat.stat count per update
     assert (
         sum(report.current_sample.stats[pid].stat.values())

--- a/test/test_report.py
+++ b/test/test_report.py
@@ -19,6 +19,7 @@ stat0 = ProcessStats(
     timestamp="2024-06-11T10:09:37-04:00",
     etime="00:00",
     cmd="cmd 1",
+    stat="stat0",
 )
 
 stat1 = ProcessStats(
@@ -29,6 +30,7 @@ stat1 = ProcessStats(
     timestamp="2024-06-11T10:13:23-04:00",
     etime="00:02",
     cmd="cmd 1",
+    stat="stat1",
 )
 
 stat2 = ProcessStats(

--- a/test/test_report.py
+++ b/test/test_report.py
@@ -60,7 +60,10 @@ def test_sample_max_one_pid() -> None:
     ex1 = Sample()
     ex1.add_pid(1, stat1)
     maxes = maxes.aggregate(ex1)
-    assert maxes.stats == {1: stat1}
+    assert maxes.stats[1].rss == stat1.rss
+    assert maxes.stats[1].vsz == stat1.vsz
+    assert maxes.stats[1].pmem == stat1.pmem
+    assert maxes.stats[1].pcpu == stat1.pcpu
 
 
 def test_sample_max_initial_values_two_pids() -> None:
@@ -82,6 +85,9 @@ def test_sample_maxtwo_pids() -> None:
     ex2 = Sample()
     ex2.add_pid(2, stat1)
     maxes = maxes.aggregate(ex2)
+    import ipdb
+
+    ipdb.set_trace()
     assert maxes.stats == {1: stat1, 2: stat1}
 
 

--- a/test/test_report.py
+++ b/test/test_report.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from collections import Counter
 from datetime import datetime
 import subprocess
 from unittest import mock
@@ -19,7 +20,7 @@ stat0 = ProcessStats(
     timestamp="2024-06-11T10:09:37-04:00",
     etime="00:00",
     cmd="cmd 1",
-    stat="stat0",
+    stat=Counter(["stat0"]),
 )
 
 stat1 = ProcessStats(
@@ -30,7 +31,7 @@ stat1 = ProcessStats(
     timestamp="2024-06-11T10:13:23-04:00",
     etime="00:02",
     cmd="cmd 1",
-    stat="stat1",
+    stat=Counter(["stat1"]),
 )
 
 stat2 = ProcessStats(
@@ -41,6 +42,7 @@ stat2 = ProcessStats(
     timestamp="2024-06-11T10:13:23-04:00",
     etime="00:02",
     cmd="cmd 1",
+    stat=Counter(["stat2"]),
 )
 
 
@@ -158,6 +160,7 @@ def test_process_stats_green(
         timestamp=datetime.now().astimezone().isoformat(),
         etime=etime,
         cmd=cmd,
+        stat=Counter(["stat0"]),
     )
 
 
@@ -183,6 +186,7 @@ def test_process_stats_red(
             timestamp=datetime.now().astimezone().isoformat(),
             etime=etime,
             cmd=cmd,
+            stat=Counter(["stat0"]),
         )
 
 


### PR DESCRIPTION
Each time we poll a process we get `stat` (status) from `ps`. This sometimes changes, so its helpful to record multiple values if they change between measurements aggregated into 1 sample. Lets just count the number of each stat.