### PR TITLE
Report $USER as .user, and store actual numeric UID as .uid

### DIFF
--- a/src/con_duct/__main__.py
+++ b/src/con_duct/__main__.py
@@ -21,7 +21,7 @@ import time
 from typing import IO, Any, Optional, TextIO
 
 __version__ = "0.4.0"
-__schema_version__ = "0.1.0"
+__schema_version__ = "0.1.1"
 
 
 lgr = logging.getLogger("con-duct")
@@ -121,10 +121,11 @@ class RecordTypes(str, Enum):
 
 @dataclass
 class SystemInfo:
-    uid: str | None
-    memory_total: int
     cpu_total: int
+    memory_total: int
     hostname: str | None
+    uid: int
+    user: str | None
 
 
 @dataclass
@@ -381,12 +382,12 @@ class Report:
 
     def get_system_info(self) -> None:
         """Gathers system information related to CPU, GPU, memory, and environment variables."""
-        uid = os.environ.get("USER")
-        hostname = socket.gethostname()
-        memory_total = os.sysconf("SC_PAGESIZE") * os.sysconf("SC_PHYS_PAGES")
-        cpu_total = os.sysconf("SC_NPROCESSORS_CONF")
         self.system_info = SystemInfo(
-            uid=uid, memory_total=memory_total, cpu_total=cpu_total, hostname=hostname
+            cpu_total=os.sysconf("SC_NPROCESSORS_CONF"),
+            memory_total=os.sysconf("SC_PAGESIZE") * os.sysconf("SC_PHYS_PAGES"),
+            hostname=socket.gethostname(),
+            uid=os.getuid(),
+            user=os.environ.get("USER"),
         )
         # GPU information
         if shutil.which("nvidia-smi") is not None:

--- a/test/test_report.py
+++ b/test/test_report.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from datetime import datetime
+import os
 import subprocess
 from unittest import mock
 import pytest
@@ -193,7 +194,8 @@ def test_system_info_sanity(mock_log_paths: mock.MagicMock) -> None:
     assert report.system_info.hostname
     assert report.system_info.cpu_total
     assert report.system_info.memory_total > 10
-    assert report.system_info.uid
+    assert report.system_info.uid == os.getuid()
+    assert report.system_info.user == os.environ.get("USER")
 
 
 @mock.patch("con_duct.__main__.shutil.which")


### PR DESCRIPTION
While at it I also sorted the records in that SystemInfo alphabetically since IMHO there is really no ultimate inherent order to them. Hence to avoid any ambiguity, alphabetic sorting is preferred.

I also removed use of temporary "single use" variables in a function -- it just makes code longer and thus harder to read (need to start matching value passed to defined somewhere above in a var) while providing no benefit.

Closes #194