### PR TITLE
Rm num_samples & num_reports from summary_format

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,7 @@ options:
                         Usage (VSZ): {average_vsz!S} Memory Peak Percentage:
                         {peak_pmem!N}% Memory Average Percentage:
                         {average_pmem!N}% CPU Peak Usage: {peak_pcpu!N}%
-                        Average CPU Usage: {average_pcpu!N}% Samples
-                        Collected: {num_samples!X} Reports Written:
-                        {num_reports!X} )
+                        Average CPU Usage: {average_pcpu!N}% )
   --colors              Use colors in duct output. (default: False)
   --clobber             Replace log files if they already exist. (default:
                         False)

--- a/src/con_duct/__main__.py
+++ b/src/con_duct/__main__.py
@@ -22,7 +22,7 @@ import time
 from typing import IO, Any, Optional, TextIO
 
 __version__ = "0.6.0"
-__schema_version__ = "0.2.1"
+__schema_version__ = "0.2.0"
 
 
 lgr = logging.getLogger("con-duct")


### PR DESCRIPTION
These variables are still available for users who provide a custom summary_format

Fixes https://github.com/con/duct/issues/188