### PR TITLE
Add start and end time to info.json

### DIFF
--- a/src/con_duct/__main__.py
+++ b/src/con_duct/__main__.py
@@ -515,6 +515,8 @@ class Report:
             "average_pcpu": self.full_run_stats.averages.pcpu,
             "num_samples": self.full_run_stats.averages.num_samples,
             "num_reports": self.number,
+            "start_time": self.start_time,
+            "end_time": self.end_time,
         }
 
     def dump_json(self) -> str:


### PR DESCRIPTION
Fixes https://github.com/con/duct/issues/193

This does not need a schema bump, so long as this is merged for the same release as https://github.com/con/duct/pull/200

Its not pretty:
```
    "start_time": 1728506948.210715,
    "end_time": 1728506949.2119823
```
<details>
<summary>Full info.json</summary>

```json

{
  "command": "sleep 1",
  "system": {
    "cpu_total": 20,
    "memory_total": 33336131584,
    "hostname": "fancy",
    "uid": 1000,
    "user": "austin"
  },
  "env": {},
  "gpu": null,
  "duct_version": "0.5.0",
  "schema_version": "0.1.1",
  "execution_summary": {
    "exit_code": 0,
    "command": "sleep 1",
    "logs_prefix": "Z_",
    "wall_clock_time": 1.0012671947479248,
    "peak_rss": 1896448,
    "average_rss": 1896448.0,
    "peak_vsz": 232374272,
    "average_vsz": 232374272.0,
    "peak_pmem": 0.0,
    "average_pmem": 0.0,
    "peak_pcpu": 0.0,
    "average_pcpu": 0.0,
    "num_samples": 9,
    "num_reports": 2,
    "start_time": 1728506948.210715,
    "end_time": 1728506949.2119823
  },
  "output_paths": {
    "stdout": "Z_stdout",
    "stderr": "Z_stderr",
    "usage": "Z_usage.json",
    "info": "Z_info.json",
    "prefix": "Z_"
  }
}
```

But sticking with the theme of keeping info.json machine readable, I've opted not to do something like

`end_time = datetime.utcfromtimestamp(data['end_time']).strftime('%Y-%m-%d %H:%M:%S')`

If we want that it can be done in a renderer.
