### PR TITLE
ENH/BF: render floats only to 2 digits after . . Allow for composing format + conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,10 @@ options:
                         Average Usage (RSS): {average_rss!S} Virtual Memory
                         Peak Usage (VSZ): {peak_vsz!S} Virtual Memory Average
                         Usage (VSZ): {average_vsz!S} Memory Peak Percentage:
-                        {peak_pmem!N}% Memory Average Percentage:
-                        {average_pmem!N}% CPU Peak Usage: {peak_pcpu!N}%
-                        Average CPU Usage: {average_pcpu!N}% )
+                        {peak_pmem:.2f!N}% Memory Average Percentage:
+                        {average_pmem:.2f!N}% CPU Peak Usage:
+                        {peak_pcpu:.2f!N}% Average CPU Usage:
+                        {average_pcpu:.2f!N}% )
   --colors              Use colors in duct output. (default: False)
   --clobber             Replace log files if they already exist. (default:
                         False)

--- a/src/con_duct/__main__.py
+++ b/src/con_duct/__main__.py
@@ -45,10 +45,10 @@ EXECUTION_SUMMARY_FORMAT = (
     "Memory Average Usage (RSS): {average_rss!S}\n"
     "Virtual Memory Peak Usage (VSZ): {peak_vsz!S}\n"
     "Virtual Memory Average Usage (VSZ): {average_vsz!S}\n"
-    "Memory Peak Percentage: {peak_pmem!N}%\n"
-    "Memory Average Percentage: {average_pmem!N}%\n"
-    "CPU Peak Usage: {peak_pcpu!N}%\n"
-    "Average CPU Usage: {average_pcpu!N}%\n"
+    "Memory Peak Percentage: {peak_pmem:.2f!N}%\n"
+    "Memory Average Percentage: {average_pmem:.2f!N}%\n"
+    "CPU Peak Usage: {peak_pcpu:.2f!N}%\n"
+    "Average CPU Usage: {average_pcpu:.2f!N}%\n"
 )
 
 
@@ -648,13 +648,21 @@ class SummaryFormatter(string.Formatter):
         if value is None:
             # TODO: could still use our formatter and make it red or smth like that
             return self.NONE
+        # if it is a composite :format!conversion, we need to split it
+        if "!" in format_spec and format_spec.index("!") > 1:
+            format_spec, conversion = format_spec.split("!")
+        else:
+            conversion = None
         try:
-            return super().format_field(value, format_spec)
-        except ValueError:
+            value_ = super().format_field(value, format_spec)
+        except ValueError as exc:
             lgr.warning(
-                f"Value: {value} is invalid for format spec {format_spec}, falling back to `str`"
+                f"Falling back to `str` formatting for {value!r} due to exception: {exc}"
             )
             return str(value)
+        if conversion:
+            return self.convert_field(value_, conversion)
+        return value_
 
 
 @dataclass

--- a/src/con_duct/__main__.py
+++ b/src/con_duct/__main__.py
@@ -650,7 +650,7 @@ class SummaryFormatter(string.Formatter):
             return self.NONE
         # if it is a composite :format!conversion, we need to split it
         if "!" in format_spec and format_spec.index("!") > 1:
-            format_spec, conversion = format_spec.split("!")
+            format_spec, conversion = format_spec.split("!", 1)
         else:
             conversion = None
         try:

--- a/test/test_formatter.py
+++ b/test/test_formatter.py
@@ -297,20 +297,40 @@ def test_summary_formatter_N_e2e_colors() -> None:
 
 @mock.patch("con_duct.__main__.LogPaths")
 @mock.patch("con_duct.__main__.subprocess.Popen")
-def test_execution_summary_formatted_wall_clock_time_invalid(
-    mock_popen: mock.MagicMock, mock_log_paths: mock.MagicMock
+@pytest.mark.parametrize("colors", [True, False])
+def test_execution_summary_formatted_wall_clock_time_nowvalid(
+    mock_popen: mock.MagicMock, mock_log_paths: mock.MagicMock, colors: bool
 ) -> None:
     mock_log_paths.prefix = "mock_prefix"
-    wall_clock_format_string = "Invalid rounding of string: {wall_clock_time:.3f!X}"
-    report = Report("_cmd", [], mock_log_paths, wall_clock_format_string, clobber=False)
-    # It should not crash and it would render even where no wallclock time yet
+    wall_clock_format_string = "Rendering: {wall_clock_time:.3f!X}"
+    report = Report(
+        "_cmd",
+        [],
+        mock_log_paths,
+        wall_clock_format_string,
+        clobber=False,
+        colors=colors,
+    )
     report.process = mock_popen
     report.process.returncode = 0
     report.start_time = 1727221840.0486171
     report.end_time = report.start_time + 1.111111111
 
+    if colors:
+        GREEN, STOP = GREEN_START, SummaryFormatter.RESET_SEQ
+    else:
+        GREEN, STOP = "", ""
+
     # Assert ValueError not raised
-    assert (
-        "Invalid rounding of string: 1.1111111640930176"
-        == report.execution_summary_formatted
+    assert f"Rendering: {GREEN}1.111{STOP}" == report.execution_summary_formatted
+
+    # It should not crash and it would render even where no wallclock time yet
+    report = Report(
+        "_cmd",
+        [],
+        mock_log_paths,
+        wall_clock_format_string,
+        clobber=False,
+        colors=colors,
     )
+    assert f"Rendering: {GREEN}nan{STOP}" == report.execution_summary_formatted

--- a/test/test_formatter.py
+++ b/test/test_formatter.py
@@ -334,3 +334,14 @@ def test_execution_summary_formatted_wall_clock_time_nowvalid(
         colors=colors,
     )
     assert f"Rendering: {GREEN}nan{STOP}" == report.execution_summary_formatted
+
+    # or if we really provide bad formatting, e.g. the opposite order of conversion and formatting
+    report = Report(
+        "_cmd",
+        [],
+        mock_log_paths,
+        "Rendering: {wall_clock_time!X:.3f}",
+        clobber=False,
+        colors=colors,
+    )
+    assert f"Rendering: {GREEN}nan{STOP}" == report.execution_summary_formatted


### PR DESCRIPTION
Also adjusted exception message.  I prefer to see original exception to get a better clue on what actually caused the problem, not an interpretation (possibly wrong since no analysis of original exception was carried out) of it.

With this change, even with colors (not visible here) we get a nice(r) rendering:

	❯ src/con_duct/__main__.py --colors --s-i 0.1 --r-i 0.5 test/data/test_script.py --memory-size 1024 --cpu-load 80 --duration 1
	2024-10-29T11:09:27-0400 [INFO    ] con-duct: duct is executing 'test/data/test_script.py --memory-size 1024 --cpu-load 80 --duration 1'...
	2024-10-29T11:09:27-0400 [INFO    ] con-duct: Log files will be written to .duct/logs/2024.10.29T11.09.27-1419353_
	this is of test of STDERR
	this is of test of STDOUT
	Test completed. Consumed 1024 MB for 1 seconds with CPU load factor 80.
	2024-10-29T11:09:28-0400 [INFO    ] con-duct: Summary:
	Exit Code: 0
	Command: test/data/test_script.py --memory-size 1024 --cpu-load 80 --duration 1
	Log files location: .duct/logs/2024.10.29T11.09.27-1419353_
	Wall Clock Time: 1.415 sec
	Memory Peak Usage (RSS): 1.1 GB
	Memory Average Usage (RSS): 898.9 MB
	Virtual Memory Peak Usage (VSZ): 1.1 GB
	Virtual Memory Average Usage (VSZ): 1.1 GB
	Memory Peak Percentage: 1.60%
	Memory Average Percentage: 1.31%
	CPU Peak Usage: 108.00%
	Average CPU Usage: 93.91%

instead of smth like (trimming to what matters)

	...
	Virtual Memory Average Usage (VSZ): 1.0 GB
	Memory Peak Percentage: 1.6%
	Memory Average Percentage: 1.2750000000000001%
	CPU Peak Usage: 104.0%
	Average CPU Usage: 92.83333333333333%