### PR TITLE
Add --fail-time option and by default remove all outputs if command fails fast

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ usage: duct [-h] [--version] [-p OUTPUT_PREFIX]
             [--summary-format SUMMARY_FORMAT] [--colors] [--clobber]
             [-l {NONE,CRITICAL,ERROR,WARNING,INFO,DEBUG}] [-q]
             [--sample-interval SAMPLE_INTERVAL]
-            [--report-interval REPORT_INTERVAL] [-c {all,none,stdout,stderr}]
-            [-o {all,none,stdout,stderr}]
+            [--report-interval REPORT_INTERVAL] [--fail-time FAIL_TIME]
+            [-c {all,none,stdout,stderr}] [-o {all,none,stdout,stderr}]
             [-t {all,system-summary,processes-samples}]
             command [command_args ...] ...
 
@@ -105,6 +105,12 @@ options:
   --report-interval REPORT_INTERVAL, --r-i REPORT_INTERVAL
                         Interval in seconds at which to report aggregated
                         data. (default: 60.0)
+  --fail-time FAIL_TIME, --f-t FAIL_TIME
+                        If command fails in less than this specified time,
+                        duct would remove logs. Set to 0 if you would like to
+                        keep logs for a failing command regardless of its run
+                        time. Set to negative (e.g. -1) if you would like to
+                        not keep logs for any failing command. (default: 3.0)
   -c {all,none,stdout,stderr}, --capture-outputs {all,none,stdout,stderr}
                         Record stdout, stderr, all, or none to log files. You
                         can also provide value via DUCT_CAPTURE_OUTPUTS env


### PR DESCRIPTION
The most annoying UX for me to use duct "by default" is the fact that while preparing target command invocation, I can make mistakes.  And then duct keeps generating those reports which are inconsueqential and need cleaning (removal) etc. And such reports have no value really.  Hence, by default, I decided that it is not worth keeping them.  If it is desired, user can use this added option to set --fail-time to 0.  But also it might be that command takes awhile to start to only to fail, and for such cases users could raise it also higher and also have logs cleared for any failed command (set to -1).