### PR TITLE
Fix issue where pillow fails to install on pypy 3.9

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -59,6 +59,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip wheel
           python -m pip install --upgrade --upgrade-strategy=eager tox
+          sudo apt-get install -y libjpeg-dev
 
       - name: Run tests with coverage
         if: matrix.toxenv == 'py'


### PR DESCRIPTION
<details><summary>Error message from pypy job</summary>

```
py: install_deps> python -I -m pip install pytest pytest-cov -e '.[all]'
  error: subprocess-exited-with-error
  
  × Building wheel for pillow (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [209 lines of output]
      running bdist_wheel
      running build
      running build_py
      creating build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/IcoImagePlugin.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/ExifTags.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/ImageCms.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/_tkinter_finder.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/MpegImagePlugin.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/ImageGrab.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/TgaImagePlugin.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/MicImagePlugin.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/XVThumbImagePlugin.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/WebPImagePlugin.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/_binary.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/BmpImagePlugin.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/EpsImagePlugin.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/TiffTags.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/ImageQt.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/ImageStat.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/GifImagePlugin.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/_util.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/_typing.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/TarIO.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/Jpeg2KImagePlugin.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/DdsImagePlugin.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/JpegPresets.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/BdfFontFile.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/PpmImagePlugin.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/ImageFile.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/ImageMorph.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/JpegImagePlugin.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/PsdImagePlugin.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/PcxImagePlugin.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/XpmImagePlugin.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/BufrStubImagePlugin.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/ImageFilter.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/WmfImagePlugin.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/PalmImagePlugin.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/IptcImagePlugin.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/QoiImagePlugin.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/report.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/__init__.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/__main__.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/ImageTk.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/PcfFontFile.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/GdImageFile.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/ImagePath.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/ImageFont.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/GimpPaletteFile.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/PSDraw.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/GbrImagePlugin.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/CurImagePlugin.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/MpoImagePlugin.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/FpxImagePlugin.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/FliImagePlugin.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/ContainerIO.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/ImageShow.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/ImageMode.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/PngImagePlugin.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/IcnsImagePlugin.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/ImageDraw.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/ImImagePlugin.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/FtexImagePlugin.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/ImageTransform.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/McIdasImagePlugin.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/MspImagePlugin.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/SunImagePlugin.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/features.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/_version.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/ImageSequence.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/ImageChops.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/_deprecate.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/ImageOps.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/ImageEnhance.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/ImageColor.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/PaletteFile.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/PdfImagePlugin.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/GimpGradientFile.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/ImageWin.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/Image.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/ImageMath.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/SpiderImagePlugin.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/BlpImagePlugin.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/FitsImagePlugin.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/ImageDraw2.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/GribStubImagePlugin.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/ImtImagePlugin.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/ImagePalette.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/PixarImagePlugin.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/FontFile.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/TiffImagePlugin.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/PcdImagePlugin.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/Hdf5StubImagePlugin.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/DcxImagePlugin.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/PdfParser.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/WalImageFile.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/XbmImagePlugin.py -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/SgiImagePlugin.py -> build/lib.linux-x86_64-pypy39/PIL
      running egg_info
      writing src/pillow.egg-info/PKG-INFO
      writing dependency_links to src/pillow.egg-info/dependency_links.txt
      writing requirements to src/pillow.egg-info/requires.txt
      writing top-level names to src/pillow.egg-info/top_level.txt
      reading manifest file 'src/pillow.egg-info/SOURCES.txt'
      reading manifest template 'MANIFEST.in'
      warning: no files found matching '*.c'
      warning: no files found matching '*.h'
      warning: no files found matching '*.sh'
      warning: no files found matching '*.txt'
      warning: no files found matching '.flake8'
      warning: no previously-included files found matching '.appveyor.yml'
      warning: no previously-included files found matching '.clang-format'
      warning: no previously-included files found matching '.coveragerc'
      warning: no previously-included files found matching '.editorconfig'
      warning: no previously-included files found matching '.readthedocs.yml'
      warning: no previously-included files found matching 'codecov.yml'
      warning: no previously-included files found matching 'renovate.json'
      warning: no previously-included files matching '.git*' found anywhere in distribution
      warning: no previously-included files matching '*.so' found anywhere in distribution
      no previously-included directories found matching '.ci'
      no previously-included directories found matching 'wheels'
      adding license file 'LICENSE'
      writing manifest file 'src/pillow.egg-info/SOURCES.txt'
      copying src/PIL/_imaging.pyi -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/_imagingcms.pyi -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/_imagingft.pyi -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/_imagingmath.pyi -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/_imagingmorph.pyi -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/_imagingtk.pyi -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/_webp.pyi -> build/lib.linux-x86_64-pypy39/PIL
      copying src/PIL/py.typed -> build/lib.linux-x86_64-pypy39/PIL
      running build_ext
      
      
      The headers or library files could not be found for jpeg,
      a required dependency when compiling Pillow from source.
      
      Please see the install instructions at:
         https://pillow.readthedocs.io/en/latest/installation/basic-installation.html
      
      Traceback (most recent call last):
        File "<string>", line 1032, in <module>
        File "/tmp/pip-build-env-0g0n0n_v/overlay/lib/pypy3.9/site-packages/setuptools/__init__.py", line 117, in setup
          return distutils.core.setup(**attrs)
        File "/tmp/pip-build-env-0g0n0n_v/overlay/lib/pypy3.9/site-packages/setuptools/_distutils/core.py", line 186, in setup
          return run_commands(dist)
        File "/tmp/pip-build-env-0g0n0n_v/overlay/lib/pypy3.9/site-packages/setuptools/_distutils/core.py", line 202, in run_commands
          dist.run_commands()
        File "/tmp/pip-build-env-0g0n0n_v/overlay/lib/pypy3.9/site-packages/setuptools/_distutils/dist.py", line 983, in run_commands
          self.run_command(cmd)
        File "/tmp/pip-build-env-0g0n0n_v/overlay/lib/pypy3.9/site-packages/setuptools/dist.py", line 999, in run_command
          super().run_command(command)
        File "/tmp/pip-build-env-0g0n0n_v/overlay/lib/pypy3.9/site-packages/setuptools/_distutils/dist.py", line 1002, in run_command
          cmd_obj.run()
        File "/tmp/pip-build-env-0g0n0n_v/overlay/lib/pypy3.9/site-packages/setuptools/command/bdist_wheel.py", line 379, in run
          self.run_command("build")
        File "/tmp/pip-build-env-0g0n0n_v/overlay/lib/pypy3.9/site-packages/setuptools/_distutils/cmd.py", line 339, in run_command
          self.distribution.run_command(command)
        File "/tmp/pip-build-env-0g0n0n_v/overlay/lib/pypy3.9/site-packages/setuptools/dist.py", line 999, in run_command
          super().run_command(command)
        File "/tmp/pip-build-env-0g0n0n_v/overlay/lib/pypy3.9/site-packages/setuptools/_distutils/dist.py", line 1002, in run_command
          cmd_obj.run()
        File "/tmp/pip-build-env-0g0n0n_v/overlay/lib/pypy3.9/site-packages/setuptools/_distutils/command/build.py", line 136, in run
          self.run_command(cmd_name)
        File "/tmp/pip-build-env-0g0n0n_v/overlay/lib/pypy3.9/site-packages/setuptools/_distutils/cmd.py", line 339, in run_command
          self.distribution.run_command(command)
        File "/tmp/pip-build-env-0g0n0n_v/overlay/lib/pypy3.9/site-packages/setuptools/dist.py", line 999, in run_command
          super().run_command(command)
        File "/tmp/pip-build-env-0g0n0n_v/overlay/lib/pypy3.9/site-packages/setuptools/_distutils/dist.py", line 1002, in run_command
          cmd_obj.run()
        File "/tmp/pip-build-env-0g0n0n_v/overlay/lib/pypy3.9/site-packages/setuptools/command/build_ext.py", line 99, in run
          _build_ext.run(self)
        File "/tmp/pip-build-env-0g0n0n_v/overlay/lib/pypy3.9/site-packages/setuptools/_distutils/command/build_ext.py", line 365, in run
          self.build_extensions()
        File "<string>", line 851, in build_extensions
      RequiredDependencyException: jpeg
      
      During handling of the above exception, another exception occurred:
      
      Traceback (most recent call last):
        File "/home/runner/work/duct/duct/.tox/py/lib/pypy3.9/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
        File "/home/runner/work/duct/duct/.tox/py/lib/pypy3.9/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
        File "/home/runner/work/duct/duct/.tox/py/lib/pypy3.9/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 251, in build_wheel
          return _build_backend().build_wheel(wheel_directory, config_settings,
        File "/tmp/pip-install-jssyq644/pillow_0e9836b5c2b6496cb7f19cc8c89915fe/_custom_build/backend.py", line 26, in build_wheel
          return super().build_wheel(wheel_directory, config_settings, metadata_directory)
        File "/tmp/pip-build-env-0g0n0n_v/overlay/lib/pypy3.9/site-packages/setuptools/build_meta.py", line 438, in build_wheel
          return _build(['bdist_wheel', '--dist-info-dir', str(metadata_directory)])
        File "/tmp/pip-build-env-0g0n0n_v/overlay/lib/pypy3.9/site-packages/setuptools/build_meta.py", line 426, in _build
          return self._build_with_temp_dir(
        File "/tmp/pip-build-env-0g0n0n_v/overlay/lib/pypy3.9/site-packages/setuptools/build_meta.py", line 407, in _build_with_temp_dir
          self.run_setup()
        File "/tmp/pip-install-jssyq644/pillow_0e9836b5c2b6496cb7f19cc8c89915fe/_custom_build/backend.py", line 20, in run_setup
          return super().run_setup(setup_script)
        File "/tmp/pip-build-env-0g0n0n_v/overlay/lib/pypy3.9/site-packages/setuptools/build_meta.py", line 320, in run_setup
          exec(code, locals())
        File "<string>", line 1048, in <module>
      RequiredDependencyException:
      
      The headers or library files could not be found for jpeg,
      a required dependency when compiling Pillow from source.
      
      Please see the install instructions at:
         https://pillow.readthedocs.io/en/latest/installation/basic-installation.html
      
      
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for pillow
ERROR: ERROR: Failed to build installable wheels for some pyproject.toml based projects (pillow)
Obtaining file:///home/runner/work/duct/duct
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Checking if build backend supports build_editable: started
  Checking if build backend supports build_editable: finished with status 'done'
  Getting requirements to build editable: started
  Getting requirements to build editable: finished with status 'done'
  Preparing editable metadata (pyproject.toml): started
  Preparing editable metadata (pyproject.toml): finished with status 'done'
Collecting pytest
  Downloading pytest-8.3.4-py3-none-any.whl.metadata (7.5 kB)
Collecting pytest-cov
  Downloading pytest_cov-6.0.0-py3-none-any.whl.metadata (27 kB)
Collecting exceptiongroup>=1.0.0rc8 (from pytest)
  Downloading exceptiongroup-1.2.2-py3-none-any.whl.metadata (6.6 kB)
Collecting iniconfig (from pytest)
  Downloading iniconfig-2.0.0-py3-none-any.whl.metadata (2.6 kB)
Collecting packaging (from pytest)
  Using cached packaging-24.2-py3-none-any.whl.metadata (3.2 kB)
Collecting pluggy<2,>=1.5 (from pytest)
  Using cached pluggy-1.5.0-py3-none-any.whl.metadata (4.8 kB)
Collecting tomli>=1 (from pytest)
  Using cached tomli-2.2.1-py3-none-any.whl.metadata (10 kB)
Collecting coverage>=7.5 (from coverage[toml]>=7.5->pytest-cov)
  Downloading coverage-7.6.10-pp39.pp310-none-any.whl.metadata (8.2 kB)
Collecting matplotlib (from con-duct==0.9.0)
  Downloading matplotlib-3.9.4-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (11 kB)
Collecting contourpy>=1.0.1 (from matplotlib->con-duct==0.9.0)
  Downloading contourpy-1.3.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (5.4 kB)
Collecting cycler>=0.10 (from matplotlib->con-duct==0.9.0)
  Downloading cycler-0.12.1-py3-none-any.whl.metadata (3.8 kB)
Collecting fonttools>=4.22.0 (from matplotlib->con-duct==0.9.0)
  Downloading fonttools-4.55.3-py3-none-any.whl.metadata (165 kB)
Collecting kiwisolver>=1.3.1 (from matplotlib->con-duct==0.9.0)
  Downloading kiwisolver-1.4.7-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (6.3 kB)
Collecting numpy>=1.23 (from matplotlib->con-duct==0.9.0)
  Downloading numpy-2.0.2-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (60 kB)
Collecting pillow>=8 (from matplotlib->con-duct==0.9.0)
  Downloading pillow-11.1.0.tar.gz (46.7 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 46.7/46.7 MB 127.5 MB/s eta 0:00:00
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
  Preparing metadata (pyproject.toml): started
  Preparing metadata (pyproject.toml): finished with status 'done'
Collecting pyparsing>=2.3.1 (from matplotlib->con-duct==0.9.0)
  Downloading pyparsing-3.2.1-py3-none-any.whl.metadata (5.0 kB)
Collecting python-dateutil>=2.7 (from matplotlib->con-duct==0.9.0)
  Downloading python_dateutil-2.9.0.post0-py2.py3-none-any.whl.metadata (8.4 kB)
Collecting importlib-resources>=3.2.0 (from matplotlib->con-duct==0.9.0)
  Downloading importlib_resources-6.5.2-py3-none-any.whl.metadata (3.9 kB)
Collecting zipp>=3.1.0 (from importlib-resources>=3.2.0->matplotlib->con-duct==0.9.0)
  Downloading zipp-3.21.0-py3-none-any.whl.metadata (3.7 kB)
Collecting six>=1.5 (from python-dateutil>=2.7->matplotlib->con-duct==0.9.0)
  Downloading six-1.17.0-py2.py3-none-any.whl.metadata (1.7 kB)
Downloading pytest-8.3.4-py3-none-any.whl (343 kB)
Downloading pytest_cov-6.0.0-py3-none-any.whl (22 kB)
Downloading coverage-7.6.10-pp39.pp310-none-any.whl (200 kB)
Downloading exceptiongroup-1.2.2-py3-none-any.whl (16 kB)
Using cached pluggy-1.5.0-py3-none-any.whl (20 kB)
Using cached tomli-2.2.1-py3-none-any.whl (14 kB)
Downloading iniconfig-2.0.0-py3-none-any.whl (5.9 kB)
Downloading matplotlib-3.9.4-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (8.3 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 8.3/8.3 MB 55.6 MB/s eta 0:00:00
Using cached packaging-24.2-py3-none-any.whl (65 kB)
Downloading contourpy-1.3.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (311 kB)
Downloading cycler-0.12.1-py3-none-any.whl (8.3 kB)
Downloading fonttools-4.55.3-py3-none-any.whl (1.1 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.1/1.1 MB 102.2 MB/s eta 0:00:00
Downloading importlib_resources-6.5.2-py3-none-any.whl (37 kB)
Downloading kiwisolver-1.4.7-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (79 kB)
Downloading numpy-2.0.2-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (19.3 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 19.3/19.3 MB 182.7 MB/s eta 0:00:00
Downloading pyparsing-3.2.1-py3-none-any.whl (107 kB)
Downloading python_dateutil-2.9.0.post0-py2.py3-none-any.whl (229 kB)
Downloading six-1.17.0-py2.py3-none-any.whl (11 kB)
Downloading zipp-3.21.0-py3-none-any.whl (9.6 kB)
Building wheels for collected packages: con-duct, pillow
  Building editable for con-duct (pyproject.toml): started
  Building editable for con-duct (pyproject.toml): finished with status 'done'
  Created wheel for con-duct: filename=con_duct-0.9.0-0.editable-py3-none-any.whl size=5540 sha256=0ce6a7ac01cdb91167634b14509fb97a681512343d7bfc9aa459c7273bc533da
  Stored in directory: /tmp/pip-ephem-wheel-cache-arforcfj/wheels/11/9f/31/48140b5ec5ff2471af47b4416d3e2ef6e8f03c70598e22b58c
  Building wheel for pillow (pyproject.toml): started
  Building wheel for pillow (pyproject.toml): finished with status 'error'
Successfully built con-duct
Failed to build pillow
py: exit 1 (16.76 seconds) /home/runner/work/duct/duct> python -I -m pip install pytest pytest-cov -e '.[all]' pid=1891
  py: FAIL code 1 (17.43 seconds)
  evaluation failed :( (17.84 seconds)

Error: Process completed with exit code 1.
```

</details>