### PR TITLE
bf: show ls results when no positional args given

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,8 +149,7 @@ positional arguments:
   {pp,plot,ls}  Available subcommands
     pp          Pretty print a JSON log.
     plot        Plot resource usage for an execution.
-    ls          Print execution information for all runs matching
-                DUCT_OUTPUT_PREFIX.
+    ls          Print execution information for all matching runs.
 
 options:
   -h, --help    show this help message and exit

--- a/src/con_duct/suite/ls.py
+++ b/src/con_duct/suite/ls.py
@@ -1,5 +1,6 @@
 import argparse
 from collections import OrderedDict
+import glob
 import json
 import logging
 from typing import Any, Dict, List, Optional
@@ -10,7 +11,7 @@ try:
 except ImportError:
     pyout = None
 import yaml
-from con_duct.__main__ import SummaryFormatter
+from con_duct.__main__ import DUCT_OUTPUT_PREFIX, SummaryFormatter
 
 lgr = logging.getLogger(__name__)
 
@@ -141,6 +142,11 @@ def pyout_ls(run_data_list: List[OrderedDict[str, Any]]) -> None:
 
 
 def ls(args: argparse.Namespace) -> int:
+
+    if not args.paths:
+        pattern = f"{DUCT_OUTPUT_PREFIX[:DUCT_OUTPUT_PREFIX.index('{')]}*"
+        args.paths = [p for p in glob.glob(pattern)]
+
     info_files = [path for path in args.paths if path.endswith("info.json")]
     run_data_raw = load_duct_runs(info_files)
     formatter = SummaryFormatter(enable_colors=args.colors)

--- a/src/con_duct/suite/main.py
+++ b/src/con_duct/suite/main.py
@@ -2,7 +2,6 @@ import argparse
 import os
 import sys
 from typing import List, Optional
-from con_duct.__main__ import DUCT_OUTPUT_PREFIX
 from con_duct.suite.ls import LS_FIELD_CHOICES, ls
 from con_duct.suite.plot import matplotlib_plot
 from con_duct.suite.pprint_json import pprint_json
@@ -51,7 +50,7 @@ def main(argv: Optional[List[str]] = None) -> None:
 
     parser_ls = subparsers.add_parser(
         "ls",
-        help="Print execution information for all runs matching DUCT_OUTPUT_PREFIX.",
+        help="Print execution information for all matching runs.",
     )
     parser_ls.add_argument(
         "-f",
@@ -85,8 +84,8 @@ def main(argv: Optional[List[str]] = None) -> None:
     parser_ls.add_argument(
         "paths",
         nargs="*",
-        default=[f"{DUCT_OUTPUT_PREFIX[:DUCT_OUTPUT_PREFIX.index('{')]}*"],
-        help="Path to duct report files, only `info.json` would be considered.",
+        help="Path to duct report files, only `info.json` would be considered. "
+        "If not provided, the program will glob for files that match DUCT_OUTPUT_PREFIX.",
     )
     parser_ls.set_defaults(func=ls)
 


### PR DESCRIPTION
Previous work removed globbing in favor of letting the shell do that work. However in the case where we have no positional args, we still need to glob for the files that match DUCT_OUTPUT_PREFIX.

Fixes https://github.com/con/duct/issues/238