### PR TITLE
Add --eval-filter

### DIFF
--- a/src/con_duct/suite/ls.py
+++ b/src/con_duct/suite/ls.py
@@ -55,7 +55,9 @@ LS_FIELD_CHOICES: List[str] = (
 MINIMUM_SCHEMA_VERSION: str = "0.2.0"
 
 
-def load_duct_runs(info_files: List[str], eval_filter: str) -> List[Dict[str, Any]]:
+def load_duct_runs(
+    info_files: List[str], eval_filter: Optional[str] = None
+) -> List[Dict[str, Any]]:
     loaded: List[Dict[str, Any]] = []
     for info_file in info_files:
         with open(info_file) as file:
@@ -70,7 +72,7 @@ def load_duct_runs(info_files: List[str], eval_filter: str) -> List[Dict[str, An
                         f"is below minimum schema version {MINIMUM_SCHEMA_VERSION}."
                     )
                     continue
-                if eval_filter and not eval(
+                if eval_filter is not None and not eval(
                     eval_filter, _flatten_dict(this), dict(re=re)
                 ):
                     continue

--- a/src/con_duct/suite/ls.py
+++ b/src/con_duct/suite/ls.py
@@ -72,9 +72,10 @@ def load_duct_runs(
                         f"is below minimum schema version {MINIMUM_SCHEMA_VERSION}."
                     )
                     continue
-                if eval_filter is not None and not eval(
+                if eval_filter is not None and not (eval_results := eval(
                     eval_filter, _flatten_dict(this), dict(re=re)
-                ):
+                )):
+                    lgr.debug("Filtering out %s due to filter results matching: %s", this, eval_results)
                     continue
 
                 loaded.append(this)

--- a/src/con_duct/suite/main.py
+++ b/src/con_duct/suite/main.py
@@ -66,7 +66,7 @@ def main(argv: Optional[List[str]] = None) -> None:
         nargs="+",
         metavar="FIELD",
         help=f"List of fields to show. Prefix is always included implicitly as the first field. "
-        f"Available choices: {', '.join(LS_FIELD_CHOICES)}.",
+        f"Available choices: {', '.join(sorted(LS_FIELD_CHOICES))}.",
         choices=LS_FIELD_CHOICES,
         default=[
             "command",
@@ -92,7 +92,7 @@ def main(argv: Optional[List[str]] = None) -> None:
         "--eval-filter",
         help=f"Python expression to filter results based on available fields. "
         f"The expression is evaluated for each entry, and only those that return True are included. "
-        f"Available fields: {', '.join(LS_FIELD_CHOICES)}. "
+        f"Available fields: {', '.join(sorted(LS_FIELD_CHOICES))}. "
         f"Example: --eval-filter \"filter_this=='yes'\" filters entries where 'filter_this' is 'yes'. "
         f"You can use 're' for regex operations (e.g., --eval-filter \"re.search('2025.02.09.*', prefix)\").",
     )

--- a/src/con_duct/suite/main.py
+++ b/src/con_duct/suite/main.py
@@ -87,6 +87,10 @@ def main(argv: Optional[List[str]] = None) -> None:
         help="Path to duct report files, only `info.json` would be considered. "
         "If not provided, the program will glob for files that match DUCT_OUTPUT_PREFIX.",
     )
+    parser_ls.add_argument(
+        "-e",
+        "--eval-filter",
+    )
     parser_ls.set_defaults(func=ls)
 
     args = parser.parse_args(argv)

--- a/src/con_duct/suite/main.py
+++ b/src/con_duct/suite/main.py
@@ -90,6 +90,11 @@ def main(argv: Optional[List[str]] = None) -> None:
     parser_ls.add_argument(
         "-e",
         "--eval-filter",
+        help=f"Python expression to filter results based on available fields. "
+        f"The expression is evaluated for each entry, and only those that return True are included. "
+        f"Available fields: {', '.join(LS_FIELD_CHOICES)}. "
+        f"Example: --eval-filter \"filter_this=='yes'\" filters entries where 'filter_this' is 'yes'. "
+        f"You can use 're' for regex operations (e.g., --eval-filter \"re.search('2025.02.09.*', prefix)\").",
     )
     parser_ls.set_defaults(func=ls)
 

--- a/test/test_suite.py
+++ b/test/test_suite.py
@@ -4,7 +4,7 @@ from io import StringIO
 import json
 import os
 import tempfile
-from typing import Any
+from typing import Any, Optional
 import unittest
 from unittest.mock import MagicMock, mock_open, patch
 import pytest
@@ -184,7 +184,7 @@ class TestLS(unittest.TestCase):
         self.temp_dir.cleanup()
 
     def _run_ls(
-        self, paths: list[str], fmt: str, args: argparse.Namespace = None
+        self, paths: list[str], fmt: str, args: Optional[argparse.Namespace] = None
     ) -> str:
         """Helper function to run ls() and capture stdout."""
         if args is None:


### PR DESCRIPTION
Fixes: https://github.com/con/duct/issues/239

- [x] Add tests
- [x] Investigate is _flatten_dict copy sufficient, or do we need deep_copy

`_flatten_dict` flattens the info dict, so we can eval-filter even parts that are not in execution_summary. Additionally, it creates a copy, so no need to .copy() 