### PR TITLE
Use versioningit for --version

### DIFF
--- a/.autorc
+++ b/.autorc
@@ -8,7 +8,6 @@
         [
             "exec",
             {
-                "afterChangelog": "bump2version \"$(printf '%s\n' \"$ARG_0\" | jq -r .bump)\"",
                 "afterRelease": "python -m build && twine upload dist/*"
             }
         ],

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,0 @@
-[bumpversion]
-current_version = 0.11.0
-commit = True
-message = [skip ci] Bump version: {current_version} → {new_version}
-tag = False

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,5 +3,3 @@ current_version = 0.11.0
 commit = True
 message = [skip ci] Bump version: {current_version} → {new_version}
 tag = False
-
-[bumpversion:file:src/con_duct/__main__.py]

--- a/.github/workflows/readme-updated.yaml
+++ b/.github/workflows/readme-updated.yaml
@@ -14,7 +14,11 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+        with:
+          # Fetch all commits so that versioningit will return something
+          # compatible with semantic-version
+          fetch-depth: 0
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
           python-version: '^3.9'
 
       - name: Install Python dependencies
-        run: python -m pip install build bump2version twine
+        run: python -m pip install build twine
 
       - name: Create release
         run: ~/auto shipit

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,6 +49,10 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          # Fetch all commits so that versioningit will return something
+          # compatible with semantic-version
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ coverage.*
 build/
 dist/
 venvs/
+
+# Produced by versioningit
+src/con_duct/_version.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,5 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 
-[tool.versioningit]
-
 [tool.versioningit.write]
 file = "src/con_duct/_version.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,12 @@
 [build-system]
-requires = ["setuptools >= 46.4.0"]
+requires = [
+  "setuptools >= 46.4.0",
+  "versioningit",
+]
 build-backend = "setuptools.build_meta"
+
+
+[tool.versioningit]
+
+[tool.versioningit.write]
+file = "src/con_duct/_version.py"

--- a/src/con_duct/__init__.py
+++ b/src/con_duct/__init__.py
@@ -1,0 +1,1 @@
+from ._version import __version__  # noqa

--- a/src/con_duct/__init__.py
+++ b/src/con_duct/__init__.py
@@ -1,1 +1,3 @@
-from ._version import __version__  # noqa
+from importlib.metadata import version
+
+__version__ = version("con-duct")

--- a/src/con_duct/__main__.py
+++ b/src/con_duct/__main__.py
@@ -6,6 +6,7 @@ from collections.abc import Iterable, Iterator
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from enum import Enum
+from importlib.metadata import version
 import json
 import logging
 import math
@@ -21,7 +22,7 @@ import threading
 import time
 from typing import IO, Any, Optional, TextIO
 
-__version__ = "0.11.0"
+__version__ = version("con-duct")
 __schema_version__ = "0.2.0"
 
 


### PR DESCRIPTION
If a released version is installed, there should be no change, the git tag should be returned. If a local version is installed, then the version should include git hash.

Fixes #237

```sh
$ duct --version
duct 0.10.1.post11+g965a136
```

And, supposedly after the next release it will just be duct 0.11.0.

I am marking this as a draft because I want to double check how this will affect release workflow 