### PR TITLE
Bolt on mergify support to get summaries from CI reported

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -65,9 +65,13 @@ jobs:
           python -m pip install --upgrade --upgrade-strategy=eager tox
           sudo apt-get install -y libjpeg-dev
 
-      - name: Run tests with coverage
+      - name: Run tests with coverage and mergify reporting
         if: matrix.toxenv == 'py'
-        run: tox -e py -- -vv --cov-report=xml
+        env:
+          MERGIFY_TOKEN: ${{ secrets.MERGIFY_TOKEN }}
+        run: |
+          pip install pytest-mergify
+          tox -e py -- -vv --cov-report=xml
 
       - name: Run generic tests
         if: matrix.toxenv != 'py'


### PR DESCRIPTION
Following loosely https://docs.mergify.com/ci-insights/pytest/ , and having defined the token org wide.

My hope for it to gain summaries of test fails across runs.