### PR TITLE
bf: define pyci environment and there add pytest-mergify as dependency

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -70,8 +70,7 @@ jobs:
         env:
           MERGIFY_TOKEN: ${{ secrets.MERGIFY_TOKEN }}
         run: |
-          pip install pytest-mergify
-          tox -e py -- -vv --cov-report=xml
+          tox -e pyci -- -vv --cov-report=xml
 
       - name: Run generic tests
         if: matrix.toxenv != 'py'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -68,7 +68,7 @@ jobs:
       - name: Run tests with coverage and mergify reporting
         if: matrix.toxenv == 'py'
         env:
-          MERGIFY_TOKEN: ${{ secrets.MERGIFY_TOKEN }}
+          MERGIFY_TOKEN: ${{ secrets.MERGIFY_CIINSIGHTS_TOKEN }}
         run: |
           tox -e pyci -- -vv --cov-report=xml
 

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,11 @@ commands =
     pytest {posargs} test
 passenv = USER
 
+[testenv:pyci]
+deps =
+    {[testenv]deps}
+    pytest-mergify
+
 [testenv:lint]
 deps =
     flake8

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,9 @@ passenv = USER
 deps =
     {[testenv]deps}
     pytest-mergify
+passenv =
+    {[testenv]passenv}
+    MERGIFY_TOKEN
 
 [testenv:lint]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,8 @@ deps =
     pytest-mergify
 passenv =
     {[testenv]passenv}
+    CI
+    GITHUB_*
     MERGIFY_TOKEN
 
 [testenv:lint]


### PR DESCRIPTION
Pre-installing does not affect environment tox would use for testing. To check: whether we end up with that original python version as before

Continuation to 
- #270 
where it was not really in effect. CI tox run should list mergify among plugins

```
plugins: cov-6.1.1, mergify-2025.4.10.1
```

but I do not want it to be added to default test env, to not always demand it