### PR TITLE
Only Debug log for ls on empty info files

### DIFF
--- a/src/con_duct/suite/ls.py
+++ b/src/con_duct/suite/ls.py
@@ -94,6 +94,16 @@ def load_duct_runs(
                     continue
 
                 loaded.append(this)
+            except json.JSONDecodeError as exc:
+                # Check if this is truly an empty file (no meaningful content)
+                if (
+                    exc.pos == 0
+                    and exc.msg == "Expecting value"
+                    and not exc.doc.strip()
+                ):
+                    lgr.debug("Skipping empty file %s", info_file)
+                else:
+                    lgr.warning("Failed to load file %s: %s", file, exc)
             except Exception as exc:
                 lgr.warning("Failed to load file %s: %s", file, exc)
     return loaded


### PR DESCRIPTION
info files are empty when the execution is still happening, but they are not open, they are pre-created.

Related https://github.com/con/duct/issues/210
https://github.com/con/duct/blob/main/src/con_duct/__main__.py#L240-L243

Currently when duct starts up, we check for those collisions, and then immediately create the files. This effectively reserves the filepaths for this execution. If we remove precreation, then we open up the possibility that a second duct process starts up with the same prefix, checks that the files aren't there, and continues because they arent. Then we have 2 processes expecting to work with the same files.

My question is how bad is this when using git-annex? Can a single file not be written/closed multiple times when wrapped with datalad run?  Wouldnt it produce just a single commit either way? 

This PR solves #273 issue minimally (by lowering the log level for empty files) but does not address the underlying issue of file precreation.  #210 

I am concerned that by removing pre-creation, we open ourselves up to the possibility of collisions-- though that would require at least 2 duct executions simultaneously using the same prefix. @yarikoptic wdyt?

Closes #273 