### PR TITLE
sanity: no-op change to show failing CI

### DIFF
--- a/src/con_duct/__main__.py
+++ b/src/con_duct/__main__.py
@@ -518,6 +518,7 @@ class Report:
         if self.usage_file is None:
             self.usage_file = open(self.log_paths.usage, "w")
         self.usage_file.write(json.dumps(self.current_sample.for_json()) + "\n")
+        # self.usage_file.flush()  # Force flush immediately
 
     @property
     def execution_summary(self) -> dict[str, Any]:


### PR DESCRIPTION
fix: pypy-310 had empty usage file