### PR TITLE
Handle noninteractive matplotlib backends

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -57,7 +57,7 @@ where = src
 
 [options.extras_require]
 all =
-    matplotlib>=3.10
+    matplotlib
     PyYAML
     pyout
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,7 +57,7 @@ where = src
 
 [options.extras_require]
 all =
-    matplotlib
+    matplotlib>=3.10
     PyYAML
     pyout
 

--- a/src/con_duct/suite/plot.py
+++ b/src/con_duct/suite/plot.py
@@ -4,11 +4,15 @@ import json
 
 
 def matplotlib_plot(args: argparse.Namespace) -> int:
-    import matplotlib
-    from matplotlib.backends import backend_registry
-    from matplotlib.backends.registry import BackendFilter
-    import matplotlib.pyplot as plt
-    import numpy as np
+    try:
+        import matplotlib
+        from matplotlib.backends import backend_registry
+        from matplotlib.backends.registry import BackendFilter
+        import matplotlib.pyplot as plt
+        import numpy as np
+    except ImportError as e:
+        print(f"con-duct plot missing required dependency: {e}")
+        return 1
 
     # Handle info.json files by reading the usage path from the file
     file_path = args.file_path

--- a/src/con_duct/suite/plot.py
+++ b/src/con_duct/suite/plot.py
@@ -6,7 +6,7 @@ import json
 def matplotlib_plot(args: argparse.Namespace) -> int:
     try:
         import matplotlib
-        from matplotlib.backends import backend_registry
+        from matplotlib.backends import backend_registry  # type: ignore[attr-defined]
         from matplotlib.backends.registry import BackendFilter
         import matplotlib.pyplot as plt
         import numpy as np
@@ -85,7 +85,11 @@ def matplotlib_plot(args: argparse.Namespace) -> int:
         print(f"Successfully rendered input file: {file_path} to output {args.output}")
     else:
         # Check if the current backend can display plots interactively
-        current_backend = matplotlib.get_backend()
+        try:
+            current_backend = matplotlib.get_backend()  # type: ignore[attr-defined]
+        except AttributeError:
+            # Fallback for matplotlib < 3.10
+            current_backend = matplotlib.rcParams["backend"]  # type: ignore[attr-defined]
         interactive_backends = backend_registry.list_builtin(BackendFilter.INTERACTIVE)
 
         # Note: This only checks builtin backends. Custom interactive backends

--- a/src/con_duct/suite/plot.py
+++ b/src/con_duct/suite/plot.py
@@ -4,6 +4,9 @@ import json
 
 
 def matplotlib_plot(args: argparse.Namespace) -> int:
+    import matplotlib
+    from matplotlib.backends import backend_registry
+    from matplotlib.backends.registry import BackendFilter
     import matplotlib.pyplot as plt
     import numpy as np
 
@@ -77,7 +80,28 @@ def matplotlib_plot(args: argparse.Namespace) -> int:
         plt.savefig(args.output)
         print(f"Successfully rendered input file: {file_path} to output {args.output}")
     else:
-        plt.show()
+        # Check if the current backend can display plots interactively
+        current_backend = matplotlib.get_backend()
+        interactive_backends = backend_registry.list_builtin(BackendFilter.INTERACTIVE)
+
+        # Note: This only checks builtin backends. Custom interactive backends
+        # would be incorrectly flagged as non-interactive. If this becomes an
+        # issue, we could fallback to try/except around plt.show()
+        if current_backend in interactive_backends:
+            plt.show()
+        else:
+            print(
+                f"Cannot display plot: your current matplotlib backend is {current_backend} "
+                f"which is a not a known interactive backend."
+            )
+            print(
+                "Either set environment variable MPLBACKEND to an interactive backend or "
+                "use --output to save the plot to a file instead."
+            )
+            print(
+                "For more info: https://matplotlib.org/stable/users/explain/figure/backends.html"
+            )
+            return 1
 
     # Exit code
     return 0

--- a/test/test_suite.py
+++ b/test/test_suite.py
@@ -332,6 +332,23 @@ class TestPlotMatplotlib(unittest.TestCase):
         assert main.execute(args) == 1
         mock_plot_save.assert_not_called()
 
+    @patch("matplotlib.get_backend", return_value="SomeOtherAgg")
+    def test_matplotlib_plot_non_interactive_backend(
+        self,
+        _mock_get_backend: MagicMock,
+    ) -> None:
+        """Test that plotting without output in non-interactive backend returns error."""
+
+        args = argparse.Namespace(
+            command="plot",
+            file_path="test/data/mriqc-example/usage.json",
+            output=None,  # No output file specified
+            func=plot.matplotlib_plot,
+            log_level="NONE",
+        )
+        result = main.execute(args)
+        assert result == 1
+
 
 class TestLS(unittest.TestCase):
     def setUp(self) -> None:

--- a/test/test_suite.py
+++ b/test/test_suite.py
@@ -370,6 +370,26 @@ class TestPlotMatplotlib(unittest.TestCase):
         result = main.execute(args)
         assert result == 1
 
+    @patch("matplotlib.pyplot.show")
+    @patch("matplotlib.get_backend", return_value="tkagg")
+    def test_matplotlib_plot_interactive_backend_with_get_backend(
+        self,
+        _mock_get_backend: MagicMock,
+        mock_show: MagicMock,
+    ) -> None:
+        """Test that plotting without output in interactive backend calls plt.show() successfully."""
+
+        args = argparse.Namespace(
+            command="plot",
+            file_path="test/data/mriqc-example/usage.json",
+            output=None,  # No output file specified
+            func=plot.matplotlib_plot,
+            log_level="NONE",
+        )
+        result = main.execute(args)
+        assert result == 0
+        mock_show.assert_called_once()
+
     @patch(
         "builtins.__import__", side_effect=ImportError("No module named 'matplotlib'")
     )

--- a/test/test_suite.py
+++ b/test/test_suite.py
@@ -332,12 +332,33 @@ class TestPlotMatplotlib(unittest.TestCase):
         assert main.execute(args) == 1
         mock_plot_save.assert_not_called()
 
-    @patch("matplotlib.get_backend", return_value="SomeOtherAgg")
+    @patch(
+        "matplotlib.get_backend",
+        side_effect=AttributeError("get_backend not available"),
+    )
+    @patch.dict("matplotlib.rcParams", {"backend": "Agg"})
     def test_matplotlib_plot_non_interactive_backend(
         self,
         _mock_get_backend: MagicMock,
     ) -> None:
         """Test that plotting without output in non-interactive backend returns error."""
+
+        args = argparse.Namespace(
+            command="plot",
+            file_path="test/data/mriqc-example/usage.json",
+            output=None,  # No output file specified
+            func=plot.matplotlib_plot,
+            log_level="NONE",
+        )
+        result = main.execute(args)
+        assert result == 1
+
+    @patch("matplotlib.get_backend", return_value="Agg")
+    def test_matplotlib_plot_non_interactive_backend_with_get_backend(
+        self,
+        _mock_get_backend: MagicMock,
+    ) -> None:
+        """Test that plotting without output in non-interactive backend returns error using get_backend."""
 
         args = argparse.Namespace(
             command="plot",

--- a/test/test_suite.py
+++ b/test/test_suite.py
@@ -349,6 +349,22 @@ class TestPlotMatplotlib(unittest.TestCase):
         result = main.execute(args)
         assert result == 1
 
+    @patch(
+        "builtins.__import__", side_effect=ImportError("No module named 'matplotlib'")
+    )
+    def test_matplotlib_plot_missing_dependency(self, _mock_import: MagicMock) -> None:
+        """Test that plotting with missing matplotlib shows helpful error."""
+        args = argparse.Namespace(
+            command="plot",
+            file_path="test/data/mriqc-example/usage.json",
+            output=None,
+            func=plot.matplotlib_plot,
+            log_level="NONE",
+        )
+
+        result = main.execute(args)
+        assert result == 1
+
 
 class TestLS(unittest.TestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
fixes https://github.com/con/duct/issues/290

I'd have called this a patch instead of a minor bump, but this will also drop support for matplotlib 3.9 since `matplotlib.get_backend` was introduced in 3.10. 

Unfortunately matplotlib 3.9 is not available with python 3.9, so I think we should hold this PR until 3.9 EOL in October 2025. 

- [ ] ~~Drop python 3.9 before merge~~