### PR TITLE
enh: Support duct config files

### DIFF
--- a/src/con_duct/__main__.py
+++ b/src/con_duct/__main__.py
@@ -1060,7 +1060,6 @@ class Config:
 
         env_vals, env_src = self._load_env()
         merged, provenance = self._merge_with_provenance(
-            defaults_as_source=True,
             file_layers=file_layers,
             env_vals=env_vals,
             env_src=env_src,
@@ -1136,7 +1135,6 @@ class Config:
 
     def _merge_with_provenance(
         self,
-        defaults_as_source: bool,  # TODO remove this
         file_layers: List[Tuple[Dict[str, Any], str]],
         env_vals: Dict[str, Any],
         env_src: Dict[str, str],
@@ -1150,8 +1148,7 @@ class Config:
         for name, spec in FIELD_SPECS.items():
             if spec.default is not None:
                 merged[spec.config_key] = spec.default
-                if defaults_as_source:
-                    src[spec.config_key] = f"default ({name})"
+                src[spec.config_key] = f"default ({name})"
 
         # Files in order
         for data, label in file_layers:

--- a/src/con_duct/__main__.py
+++ b/src/con_duct/__main__.py
@@ -121,12 +121,11 @@ class ConfigurableArgumentParser(argparse.ArgumentParser):
             # Precedence: original default < config < env var
 
             # Override with config value if it exists
-            if self.config:
-                try:
-                    config_value = getattr(self.config, config_key)
-                    kwargs["default"] = config_value
-                except AttributeError:
-                    pass
+            try:
+                config_value = getattr(self.config, config_key)
+                kwargs["default"] = config_value
+            except AttributeError:
+                pass
 
             # Override with env var if it exists (highest precedence)
             env_value = os.getenv(env_var)

--- a/src/con_duct/__main__.py
+++ b/src/con_duct/__main__.py
@@ -311,11 +311,6 @@ FIELD_SPECS: Dict[str, FieldSpec] = {
 }
 
 
-def canonical_default(name: str) -> Any:
-    """Get the canonical default value for a field."""
-    return FIELD_SPECS[name].default
-
-
 def cli_flag(name: str) -> str:
     """Get the CLI flag representation for a field."""
     spec = FIELD_SPECS[name]
@@ -334,15 +329,12 @@ class CustomHelpFormatter(argparse.HelpFormatter):
         help_text = action.help or ""
 
         # Add default value if available
-        if (
-            hasattr(action, "canonical_default")
-            and action.canonical_default is not None
-        ):
+        if hasattr(action, "spec_default") and action.spec_default is not None:
             if help_text:
                 help_text = help_text.rstrip()
             # Format the default value nicely
-            default_str = str(action.canonical_default)
-            if isinstance(action.canonical_default, str):
+            default_str = str(action.spec_default)
+            if isinstance(action.spec_default, str):
                 # Truncate long strings
                 if len(default_str) > 50:
                     default_str = default_str[:47] + "..."
@@ -376,8 +368,8 @@ def build_parser() -> argparse.ArgumentParser:
         default=DEFAULT_CONFIG_PATHS,
         help="Configuration file path",
     )
-    # Store canonical default for help text
-    config_action.canonical_default = DEFAULT_CONFIG_PATHS
+    # Store default for help text
+    config_action.spec_default = DEFAULT_CONFIG_PATHS
 
     # Add --dump-config
     parser.add_argument(
@@ -416,8 +408,8 @@ def build_parser() -> argparse.ArgumentParser:
                 help=spec.help,
             )
 
-            # Store canonical default and env_var for help text
-            action.canonical_default = spec.default
+            # Store default and env_var for help text
+            action.spec_default = spec.default
             if spec.env_var:
                 action.env_var = spec.env_var
 
@@ -444,8 +436,8 @@ def build_parser() -> argparse.ArgumentParser:
 
             action = parser.add_argument(*names, dest=name, **kwargs)
 
-            # Store canonical default and env_var for help text
-            action.canonical_default = spec.default
+            # Store default and env_var for help text
+            action.spec_default = spec.default
             if spec.env_var:
                 action.env_var = spec.env_var
 

--- a/src/con_duct/__main__.py
+++ b/src/con_duct/__main__.py
@@ -51,19 +51,7 @@ configuration:
   file < environment variables < command line arguments.
 
   Default values shown below reflect the current configuration (built-in defaults
-  or loaded from config file).
-
-environment variables:
-  Many duct options can be configured by environment variables (which are
-  overridden by command line options).
-
-  DUCT_LOG_LEVEL: see --log-level
-  DUCT_OUTPUT_PREFIX: see --output-prefix
-  DUCT_SUMMARY_FORMAT: see --summary-format
-  DUCT_SAMPLE_INTERVAL: see --sample-interval
-  DUCT_REPORT_INTERVAL: see --report-interval
-  DUCT_CAPTURE_OUTPUTS: see --capture-outputs
-  DUCT_MESSAGE: see --message
+  or loaded from config file). Environment variables are listed with each option
 """
 
 ENV_PREFIXES = ("PBS_", "SLURM_", "OSG")
@@ -225,6 +213,17 @@ class CustomHelpFormatter(argparse.ArgumentDefaultsHelpFormatter):
     def _fill_text(self, text: str, width: int, _indent: str) -> str:
         # Override _fill_text to respect the newlines and indentation in descriptions
         return "\n".join([textwrap.fill(line, width) for line in text.splitlines()])
+
+    def _get_help_string(self, action):
+        help_text = super()._get_help_string(action)
+
+        # Add environment variable info if available
+        if hasattr(action, "env_var") and action.env_var:
+            if help_text:
+                help_text = help_text.rstrip()
+                help_text += f" Can also be specified with environment variable {action.env_var}."
+
+        return help_text
 
 
 def assert_num(*values: Any) -> None:
@@ -921,8 +920,7 @@ class Arguments:
             help="File string format to be used as a prefix for the files -- the captured "
             "stdout and stderr and the resource usage logs. The understood variables are "
             "{datetime}, {datetime_filesafe}, and {pid}. "
-            "Leading directories will be created if they do not exist. "
-            "You can also provide value via DUCT_OUTPUT_PREFIX env variable. ",
+            "Leading directories will be created if they do not exist.",
         )
         parser.add_argument(
             "--summary-format",
@@ -934,7 +932,7 @@ class Arguments:
             "!S: Converts filesizes to human readable units, green if measured, red if None. "
             "!E: Colors exit code, green if falsey, red if truthy, and red if None. "
             "!X: Colors green if truthy, red if falsey. "
-            "!N: Colors green if not None, red if None",
+            "!N: Colors green if not None, red if None.",
         )
         parser.add_argument(
             "--colors",
@@ -962,7 +960,7 @@ class Arguments:
             "-q",
             "--quiet",
             action="store_true",
-            help="[deprecated, use log level NONE] Disable duct logging output (to stderr)",
+            help="[deprecated, use log level NONE] Disable duct logging output (to stderr).",
         )
         parser.add_argument(
             "--sample-interval",
@@ -999,8 +997,7 @@ class Arguments:
             env_var="DUCT_CAPTURE_OUTPUTS",
             choices=list(Outputs),
             type=Outputs,
-            help="Record stdout, stderr, all, or none to log files. "
-            "You can also provide value via DUCT_CAPTURE_OUTPUTS env variable.",
+            help="Record stdout, stderr, all, or none to log files.",
         )
         parser.add_argument(
             "-o",
@@ -1018,7 +1015,7 @@ class Arguments:
             env_var="DUCT_RECORD_TYPES",
             choices=list(RecordTypes),
             type=RecordTypes,
-            help="Record system-summary, processes-samples, or all",
+            help="Record system-summary, processes-samples, or all.",
         )
         parser.add_argument(
             "-m",
@@ -1026,8 +1023,7 @@ class Arguments:
             type=str,
             default=config.message,
             env_var="DUCT_MESSAGE",
-            help="Record a descriptive message about the purpose of this execution. "
-            "You can also provide value via DUCT_MESSAGE env variable.",
+            help="Record a descriptive message about the purpose of this execution.",
         )
         parser.add_argument(
             "--mode",

--- a/src/con_duct/__main__.py
+++ b/src/con_duct/__main__.py
@@ -45,6 +45,14 @@ limitations:
   If a command spawns child processes, duct will collect data on them, but
   duct exits as soon as the primary process exits.
 
+configuration:
+  Many options can be configured via JSON config file (--config), environment
+  variables, or command line arguments. Precedence: built-in defaults < config
+  file < environment variables < command line arguments.
+
+  Default values shown below reflect the current configuration (built-in defaults
+  or loaded from config file).
+
 environment variables:
   Many duct options can be configured by environment variables (which are
   overridden by command line options).

--- a/src/con_duct/__main__.py
+++ b/src/con_duct/__main__.py
@@ -164,12 +164,6 @@ class Config:
     """Simple configuration loader for duct."""
 
     def __init__(self, defaults: dict, config_path: str = None):
-        """Load configuration from a JSON file with defaults.
-
-        Args:
-            defaults: Default configuration values (required)
-            config_path: Path to the JSON configuration file (optional)
-        """
         self.config_path = config_path
         self.data = defaults.copy()
 
@@ -186,25 +180,12 @@ class Config:
             sys.exit(1)
 
     def __getattr__(self, key: str) -> Any:
-        """Get a configuration value as an attribute.
-
-        Args:
-            key: Configuration key
-
-        Returns:
-            Configuration value or raises AttributeError
-        """
-        # Simple flat access - just check if key exists in data
         if key in self.data:
             return self.data[key]
-
-        # If not found, raise AttributeError (standard for __getattr__)
         raise AttributeError(f"Config has no attribute '{key}'")
 
     def __dir__(self):
-        """Return list of available attributes for tab completion."""
-        attrs = set(super().__dir__())  # Get default attributes
-        # Add top-level keys from data
+        attrs = set(super().__dir__())
         attrs.update(self.data.keys())
         return list(attrs)
 
@@ -900,7 +881,6 @@ class Arguments:
         parser.add_argument(
             "command_args", nargs=argparse.REMAINDER, help="Arguments for the command."
         )
-        # TODO(CONFIG
         parser.add_argument(
             "-p",
             "--output-prefix",
@@ -913,7 +893,6 @@ class Arguments:
             "Leading directories will be created if they do not exist. "
             "You can also provide value via DUCT_OUTPUT_PREFIX env variable. ",
         )
-        # TODO(CONFIG
         parser.add_argument(
             "--summary-format",
             type=str,
@@ -926,7 +905,6 @@ class Arguments:
             "!X: Colors green if truthy, red if falsey. "
             "!N: Colors green if not None, red if None",
         )
-        # TODO(CONFIG
         parser.add_argument(
             "--colors",
             action="store_true",
@@ -934,14 +912,12 @@ class Arguments:
             env_var="DUCT_COLORS",
             help="Use colors in duct output.",
         )
-        # TODO(CONFIG
         parser.add_argument(
             "--clobber",
             action="store_true",
             default=config.clobber,
             help="Replace log files if they already exist.",
         )
-        # TODO(CONFIG
         parser.add_argument(
             "-l",
             "--log-level",
@@ -957,7 +933,6 @@ class Arguments:
             action="store_true",
             help="[deprecated, use log level NONE] Disable duct logging output (to stderr)",
         )
-        # TODO(CONFIG
         parser.add_argument(
             "--sample-interval",
             "--s-i",
@@ -968,7 +943,6 @@ class Arguments:
             "Sample interval must be less than or equal to report interval, and it achieves the "
             "best results when sample is significantly less than the runtime of the process.",
         )
-        # TODO(CONFIG
         parser.add_argument(
             "--report-interval",
             "--r-i",
@@ -977,7 +951,6 @@ class Arguments:
             env_var="DUCT_REPORT_INTERVAL",
             help="Interval in seconds at which to report aggregated data.",
         )
-        # TODO(CONFIG
         parser.add_argument(
             "--fail-time",
             "--f-t",
@@ -988,7 +961,6 @@ class Arguments:
             "Set to 0 if you would like to keep logs for a failing command regardless of its run time. "
             "Set to negative (e.g. -1) if you would like to not keep logs for any failing command.",
         )
-        # TODO(CONFIG
         parser.add_argument(
             "-c",
             "--capture-outputs",
@@ -999,6 +971,7 @@ class Arguments:
             help="Record stdout, stderr, all, or none to log files. "
             "You can also provide value via DUCT_CAPTURE_OUTPUTS env variable.",
         )
+        # TODO add env var/config
         parser.add_argument(
             "-o",
             "--outputs",
@@ -1007,6 +980,7 @@ class Arguments:
             type=Outputs,
             help="Print stdout, stderr, all, or none to stdout/stderr respectively.",
         )
+        # TODO add env var/config
         parser.add_argument(
             "-t",
             "--record-types",
@@ -1015,7 +989,6 @@ class Arguments:
             type=RecordTypes,
             help="Record system-summary, processes-samples, or all",
         )
-        # TODO(CONFIG
         parser.add_argument(
             "-m",
             "--message",
@@ -1025,7 +998,7 @@ class Arguments:
             help="Record a descriptive message about the purpose of this execution. "
             "You can also provide value via DUCT_MESSAGE env variable.",
         )
-        # TODO(add env var and add to config)
+        # TODO(add env var/config)
         parser.add_argument(
             "--mode",
             default="new-session",

--- a/src/con_duct/__main__.py
+++ b/src/con_duct/__main__.py
@@ -92,6 +92,9 @@ DEFAULT_CONFIG = {
     "report_interval": 60.0,
     "fail_time": 3.0,
     "capture_outputs": "all",
+    "outputs": "all",
+    "record_types": "all",
+    "mode": "new-session",
     "message": "",
 }
 
@@ -971,20 +974,20 @@ class Arguments:
             help="Record stdout, stderr, all, or none to log files. "
             "You can also provide value via DUCT_CAPTURE_OUTPUTS env variable.",
         )
-        # TODO add env var/config
         parser.add_argument(
             "-o",
             "--outputs",
-            default="all",
+            default=config.outputs,
+            env_var="DUCT_OUTPUTS",
             choices=list(Outputs),
             type=Outputs,
             help="Print stdout, stderr, all, or none to stdout/stderr respectively.",
         )
-        # TODO add env var/config
         parser.add_argument(
             "-t",
             "--record-types",
-            default="all",
+            default=config.record_types,
+            env_var="DUCT_RECORD_TYPES",
             choices=list(RecordTypes),
             type=RecordTypes,
             help="Record system-summary, processes-samples, or all",
@@ -998,10 +1001,10 @@ class Arguments:
             help="Record a descriptive message about the purpose of this execution. "
             "You can also provide value via DUCT_MESSAGE env variable.",
         )
-        # TODO(add env var/config)
         parser.add_argument(
             "--mode",
-            default="new-session",
+            default=config.mode,
+            env_var="DUCT_MODE",
             choices=list(SessionMode),
             type=SessionMode,
             help="Session mode: 'new-session' creates a new session for the command (default), "

--- a/src/con_duct/__main__.py
+++ b/src/con_duct/__main__.py
@@ -311,12 +311,6 @@ FIELD_SPECS: Dict[str, FieldSpec] = {
 }
 
 
-def cli_flag(name: str) -> str:
-    """Get the CLI flag representation for a field."""
-    spec = FIELD_SPECS[name]
-    return f"--{spec.config_key}"
-
-
 class CustomHelpFormatter(argparse.HelpFormatter):
     """Custom help formatter that shows defaults and environment variables."""
 
@@ -1171,7 +1165,7 @@ class Config:
             if k in FIELD_SPECS:
                 config_key = FIELD_SPECS[k].config_key
                 merged[config_key] = v
-                src[config_key] = f"CLI: {cli_flag(k)}"
+                src[config_key] = f"CLI: --{config_key}"
 
         return merged, src
 

--- a/src/con_duct/__main__.py
+++ b/src/con_duct/__main__.py
@@ -393,9 +393,9 @@ def build_parser() -> argparse.ArgumentParser:
                 action.env_var = spec.env_var
 
         else:  # kind == "value"
-            # Regular value arguments - let ArgumentDefaultsHelpFormatter handle defaults
+            # Regular value arguments - use SUPPRESS so only explicit values override config
             kwargs = {
-                "default": spec.default,  # Set actual default for formatter
+                "default": argparse.SUPPRESS,  # Don't inject defaults
                 "help": spec.help,
                 "type": spec.cast,
             }
@@ -1163,10 +1163,13 @@ class Config:
         # Files in order
         for data, label in file_layers:
             for k, v in data.items():
+                # Convert both hyphen and underscore formats to underscore to match FIELD_SPECS
                 spec_key = k.replace("-", "_")
                 if spec_key in FIELD_SPECS and FIELD_SPECS[spec_key].file_configurable:
-                    merged[k] = v
-                    src[k] = label
+                    # Store using hyphenated key for consistency
+                    config_key = spec_key.replace("_", "-")
+                    merged[config_key] = v
+                    src[config_key] = label
 
         # Environment variables
         for k, v in env_vals.items():

--- a/src/con_duct/__main__.py
+++ b/src/con_duct/__main__.py
@@ -54,6 +54,7 @@ configuration:
   or loaded from config file). Environment variables are listed with each option.
 """
 
+DEFAULT_CONFIG_PATHS = "/etc/duct/config.json:${XDG_CONFIG_HOME:-~/.config}/duct/config.json:.duct/config.json"  # noqa B950
 ENV_PREFIXES = ("PBS_", "SLURM_", "OSG")
 SUFFIXES = {
     "stdout": "stdout",
@@ -386,10 +387,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--version", action="version", version=f"%(prog)s {__version__}"
     )
-
     # Add config manually (not in FIELD_SPECS)
-    DEFAULT_CONFIG_PATHS = "/etc/duct/config.json:${XDG_CONFIG_HOME:-~/.config}/duct/config.json:.duct/config.json"  # noqa B950
-
     config_action = parser.add_argument(
         "-C",
         "--config",

--- a/src/con_duct/__main__.py
+++ b/src/con_duct/__main__.py
@@ -152,7 +152,7 @@ def src_cli(flag: str) -> str:
 class FieldSpec:
     """Specification for a configuration field."""
 
-    kind: str  # "bool" | "value" | "positional"
+    kind: str  # "bool" | "value"
     default: Any
     cast: Callable[[Any], Any]
     help: str
@@ -419,11 +419,7 @@ def build_parser() -> argparse.ArgumentParser:
     # Add all fields from specs
     for name, spec in FIELD_SPECS.items():
 
-        if spec.kind == "positional":
-            # Skip positional arguments (we don't have any in FIELD_SPECS now)
-            continue
-
-        elif spec.kind == "bool":
+        if spec.kind == "bool":
             # Simple boolean flags (just --flag, no --no-flag)
             names = []
             if spec.alt_flag_names:
@@ -1226,9 +1222,6 @@ class Config:
         errors: List[str] = []
 
         for name, spec in FIELD_SPECS.items():
-            # Skip CLI-only positional args
-            if not spec.file_configurable and spec.kind == "positional":
-                continue
 
             val = raw.get(spec.config_key, spec.default)
 
@@ -1443,7 +1436,7 @@ def main() -> None:
 
     # Check for --dump-config first to avoid command validation
     if "--dump-config" in sys.argv:
-        # Add dummy command to avoid positional arg error, then parse
+        # Add dummy command to avoid missing required positional args, then parse
         argv_with_dummy = [arg for arg in sys.argv if arg != "--dump-config"] + [
             "--dump-config",
             "dummy",

--- a/src/con_duct/__main__.py
+++ b/src/con_duct/__main__.py
@@ -1168,9 +1168,6 @@ class Config:
 
         # CLI arguments
         for k, v in cli_vals.items():
-            # TODO this maybe should be removed now?
-            if k == "config":  # Skip special CLI-only options
-                continue
             if k in FIELD_SPECS:
                 config_key = FIELD_SPECS[k].config_key
                 merged[config_key] = v

--- a/src/con_duct/__main__.py
+++ b/src/con_duct/__main__.py
@@ -127,18 +127,6 @@ class SessionMode(str, Enum):
 
 
 # ---------- Config system helper functions ----------
-def bool_from_str(x: Any) -> bool:
-    """Convert various string representations to boolean."""
-    if isinstance(x, bool):
-        return x
-    s = str(x).strip().lower()
-    if s in {"1", "true", "yes", "on"}:
-        return True
-    if s in {"0", "false", "no", "off"}:
-        return False
-    raise ValueError(f"invalid boolean: {x!r}")
-
-
 def src_default(name: str) -> str:
     """Format source label for default value."""
     return f"default ({name})"
@@ -180,6 +168,18 @@ class FieldSpec:
 
 
 # ---------- Validation functions ----------
+def bool_from_str(x: Any) -> bool:
+    """Convert various string representations to boolean."""
+    if isinstance(x, bool):
+        return x
+    s = str(x).strip().lower()
+    if s in {"1", "true", "yes", "on"}:
+        return True
+    if s in {"0", "false", "no", "off"}:
+        return False
+    raise ValueError(f"invalid boolean: {x!r}")
+
+
 def validate_positive(v: float) -> float:
     """Validate that a value is positive."""
     if v <= 0:

--- a/src/con_duct/__main__.py
+++ b/src/con_duct/__main__.py
@@ -322,11 +322,7 @@ def canonical_default(name: str) -> Any:
 
 def cli_flag(name: str) -> str:
     """Get the CLI flag representation for a field."""
-    spec = FIELD_SPECS[name]
-    # Convert underscore to hyphen for CLI flags
     flag_name = name.replace("_", "-")
-    if spec.kind == "bool":
-        return f"--{flag_name} / --no-{flag_name}"
     return f"--{flag_name}"
 
 

--- a/src/con_duct/__main__.py
+++ b/src/con_duct/__main__.py
@@ -332,19 +332,16 @@ class CustomHelpFormatter(argparse.HelpFormatter):
         if hasattr(action, "spec_default") and action.spec_default is not None:
             if help_text:
                 help_text = help_text.rstrip()
-            # Format the default value nicely
-            default_str = str(action.spec_default)
-            if isinstance(action.spec_default, str):
-                # Truncate long strings
-                if len(default_str) > 50:
-                    default_str = default_str[:47] + "..."
-            help_text += f" (default: {default_str})"
+            help_text += f" (default: {str(action.spec_default)})"
 
         # Add environment variable info if available
         if hasattr(action, "env_var") and action.env_var:
             if help_text:
                 help_text = help_text.rstrip()
             help_text += f" [env: {action.env_var}]"
+
+        # Escape percent signs to prevent argparse formatting errors
+        help_text = help_text.replace("%", "%%")
 
         return help_text
 

--- a/src/con_duct/__main__.py
+++ b/src/con_duct/__main__.py
@@ -87,6 +87,12 @@ DEFAULT_CONFIG = {
     "summary_format": _EXECUTION_SUMMARY_FORMAT,
     "colors": False,
     "log_level": "INFO",
+    "clobber": False,
+    "sample_interval": 1.0,
+    "report_interval": 60.0,
+    "fail_time": 3.0,
+    "capture_outputs": "all",
+    "message": "",
 }
 
 
@@ -925,6 +931,7 @@ class Arguments:
         parser.add_argument(
             "--colors",
             action="store_true",
+            default=config.colors,
             env_var="DUCT_COLORS",
             help="Use colors in duct output.",
         )
@@ -932,6 +939,7 @@ class Arguments:
         parser.add_argument(
             "--clobber",
             action="store_true",
+            default=config.clobber,
             help="Replace log files if they already exist.",
         )
         # TODO(CONFIG
@@ -955,7 +963,8 @@ class Arguments:
             "--sample-interval",
             "--s-i",
             type=float,
-            default=float(os.getenv("DUCT_SAMPLE_INTERVAL", "1.0")),
+            default=config.sample_interval,
+            env_var="DUCT_SAMPLE_INTERVAL",
             help="Interval in seconds between status checks of the running process. "
             "Sample interval must be less than or equal to report interval, and it achieves the "
             "best results when sample is significantly less than the runtime of the process.",
@@ -965,7 +974,8 @@ class Arguments:
             "--report-interval",
             "--r-i",
             type=float,
-            default=float(os.getenv("DUCT_REPORT_INTERVAL", "60.0")),
+            default=config.report_interval,
+            env_var="DUCT_REPORT_INTERVAL",
             help="Interval in seconds at which to report aggregated data.",
         )
         # TODO(CONFIG
@@ -973,7 +983,8 @@ class Arguments:
             "--fail-time",
             "--f-t",
             type=float,
-            default=float(os.getenv("DUCT_FAIL_TIME", "3.0")),
+            default=config.fail_time,
+            env_var="DUCT_FAIL_TIME",
             help="If command fails in less than this specified time (seconds), duct would remove logs. "
             "Set to 0 if you would like to keep logs for a failing command regardless of its run time. "
             "Set to negative (e.g. -1) if you would like to not keep logs for any failing command.",
@@ -982,7 +993,8 @@ class Arguments:
         parser.add_argument(
             "-c",
             "--capture-outputs",
-            default=os.getenv("DUCT_CAPTURE_OUTPUTS", "all"),
+            default=config.capture_outputs,
+            env_var="DUCT_CAPTURE_OUTPUTS",
             choices=list(Outputs),
             type=Outputs,
             help="Record stdout, stderr, all, or none to log files. "
@@ -1009,7 +1021,8 @@ class Arguments:
             "-m",
             "--message",
             type=str,
-            default=os.getenv("DUCT_MESSAGE", ""),
+            default=config.message,
+            env_var="DUCT_MESSAGE",
             help="Record a descriptive message about the purpose of this execution. "
             "You can also provide value via DUCT_MESSAGE env variable.",
         )

--- a/src/con_duct/__main__.py
+++ b/src/con_duct/__main__.py
@@ -1224,13 +1224,6 @@ class Config:
 
         return clean, errors
 
-    # TODO lets not make a property here, lets just override config_key in the spec
-    # Provide compatibility properties for special names that differ from field names
-    @property
-    def session_mode(self) -> SessionMode:
-        """Alias for mode field for backward compatibility."""
-        return self.mode
-
     def dump_config(self) -> None:
         """Print the final merged config with value sources."""
         config_dump = {}
@@ -1503,7 +1496,7 @@ def execute(config: Config, command: str, command_args: List[str]) -> int:
             [str(command)] + command_args,
             stdout=stdout_file,
             stderr=stderr_file,
-            start_new_session=(config.session_mode == SessionMode.NEW_SESSION),
+            start_new_session=(config.mode == SessionMode.NEW_SESSION),
             cwd=report.working_directory,
         )
     except FileNotFoundError:
@@ -1521,7 +1514,7 @@ def execute(config: Config, command: str, command_args: List[str]) -> int:
     lgr.info("duct %s is executing %r...", __version__, full_command)
     lgr.info("Log files will be written to %s", log_paths.prefix)
     try:
-        if config.session_mode == SessionMode.NEW_SESSION:
+        if config.mode == SessionMode.NEW_SESSION:
             report.session_id = os.getsid(
                 process.pid
             )  # Get session ID of the new process

--- a/src/con_duct/__main__.py
+++ b/src/con_duct/__main__.py
@@ -254,7 +254,7 @@ FIELD_SPECS: Dict[str, FieldSpec] = {
     "capture_outputs": FieldSpec(
         kind="value",
         default=Outputs.ALL,
-        cast=lambda x: Outputs(x) if isinstance(x, str) else x,
+        cast=Outputs,
         help="Record stdout, stderr, all, or none to log files",
         config_key="capture-outputs",
         env_var="DUCT_CAPTURE_OUTPUTS",
@@ -264,7 +264,7 @@ FIELD_SPECS: Dict[str, FieldSpec] = {
     "outputs": FieldSpec(
         kind="value",
         default=Outputs.ALL,
-        cast=lambda x: Outputs(x) if isinstance(x, str) else x,
+        cast=Outputs,
         help="Print stdout, stderr, all, or none",
         config_key="outputs",
         env_var="DUCT_OUTPUTS",
@@ -274,7 +274,7 @@ FIELD_SPECS: Dict[str, FieldSpec] = {
     "record_types": FieldSpec(
         kind="value",
         default=RecordTypes.ALL,
-        cast=lambda x: RecordTypes(x) if isinstance(x, str) else x,
+        cast=RecordTypes,
         help="Record system-summary, processes-samples, or all",
         config_key="record-types",
         env_var="DUCT_RECORD_TYPES",
@@ -284,7 +284,7 @@ FIELD_SPECS: Dict[str, FieldSpec] = {
     "mode": FieldSpec(
         kind="value",
         default=SessionMode.NEW_SESSION,
-        cast=lambda x: SessionMode(x) if isinstance(x, str) else x,
+        cast=SessionMode,
         help="Session mode for command execution",
         config_key="mode",
         env_var="DUCT_MODE",

--- a/src/con_duct/__main__.py
+++ b/src/con_duct/__main__.py
@@ -126,10 +126,6 @@ class SessionMode(str, Enum):
         return self.value
 
 
-# ---------- Config system helper functions ----------
-
-
-# ---------- Field specification ----------
 @dataclass(frozen=True)
 class FieldSpec:
     """Specification for a configuration field."""
@@ -149,7 +145,6 @@ class FieldSpec:
     nargs: Optional[Any] = None
 
 
-# ---------- Validation functions ----------
 def bool_from_str(x: Any) -> bool:
     """Convert various string representations to boolean."""
     if isinstance(x, bool):
@@ -177,7 +172,6 @@ def validate_sample_report_interval(sample: float, report: float) -> None:
         )
 
 
-# ---------- Field specifications ----------
 FIELD_SPECS: Dict[str, FieldSpec] = {
     "output_prefix": FieldSpec(
         kind="value",

--- a/src/con_duct/__main__.py
+++ b/src/con_duct/__main__.py
@@ -910,7 +910,7 @@ class Config:
 
     def _load_and_validate(self) -> None:
         """Load configuration from all sources and validate it."""
-        config_paths = self._expand_config_paths(self._cli_args["config"])
+        config_paths = self._expand_config_paths(self._cli_args.get("config", ""))
         file_layers = self._load_files(config_paths)
 
         env_vals, env_src = self._load_env()

--- a/src/con_duct/__main__.py
+++ b/src/con_duct/__main__.py
@@ -190,7 +190,7 @@ def build_parser() -> argparse.ArgumentParser:
     config_action = parser.add_argument(
         "-C",
         "--config",
-        default=DEFAULT_CONFIG_PATHS,
+        default=argparse.SUPPRESS,
         help="Configuration file path",
     )
     # Store default for help text
@@ -910,7 +910,12 @@ class Config:
 
     def _load_and_validate(self) -> None:
         """Load configuration from all sources and validate it."""
-        config_paths = self._expand_config_paths(self._cli_args.get("config", ""))
+        config_paths_str = (
+            self._cli_args.get("config")
+            or os.environ.get("DUCT_CONFIG")
+            or DEFAULT_CONFIG_PATHS
+        )
+        config_paths = self._expand_config_paths(config_paths_str)
         file_layers = self._load_files(config_paths)
 
         env_vals, env_src = self._load_env()

--- a/src/con_duct/__main__.py
+++ b/src/con_duct/__main__.py
@@ -1255,7 +1255,6 @@ def execute(args: Arguments) -> int:
         lgr.disabled = True
     else:
         lgr.setLevel(args.log_level)
-    lgr.debug("TEST")
     log_paths = LogPaths.create(args.output_prefix, pid=os.getpid())
     log_paths.prepare_paths(args.clobber, args.capture_outputs)
     stdout, stderr = prepare_outputs(args.capture_outputs, args.outputs, log_paths)

--- a/src/con_duct/__main__.py
+++ b/src/con_duct/__main__.py
@@ -1382,6 +1382,26 @@ def remove_files(log_paths: LogPaths, assert_empty: bool = False) -> None:
             os.remove(file_path)
 
 
+def handle_dump_config(parser: argparse.ArgumentParser) -> None:
+    """Handle --dump-config option and exit if present."""
+    if "--dump-config" not in sys.argv:
+        return
+
+    # Add dummy command to avoid missing required positional args, then parse
+    argv_with_dummy = [arg for arg in sys.argv if arg != "--dump-config"] + [
+        "--dump-config",
+        "dummy",
+    ]
+    cli_args = vars(parser.parse_args(argv_with_dummy[1:]))  # Skip script name
+    # Remove non FieldSpec Args
+    cli_args.pop("dump_config", False)
+    cli_args.pop("command", None)
+    cli_args.pop("command_args", None)
+    config = Config(cli_args)
+    config.dump_config()
+    sys.exit(0)
+
+
 def main() -> None:
     # TODO lets make this logger.Error instead so we can show configfile load issues
     # Set up basic logging configuration (level will be set properly in execute)
@@ -1391,24 +1411,7 @@ def main() -> None:
         level=logging.INFO,  # Use default level initially
     )
     parser = build_parser()
-
-    # TODO mv to function
-    # Check for --dump-config first to avoid command validation
-    if "--dump-config" in sys.argv:
-        # Add dummy command to avoid missing required positional args, then parse
-        argv_with_dummy = [arg for arg in sys.argv if arg != "--dump-config"] + [
-            "--dump-config",
-            "dummy",
-        ]
-        cli_args = vars(parser.parse_args(argv_with_dummy[1:]))  # Skip script name
-        # Remove non FieldSpec Args
-        cli_args.pop("dump_config", False)
-        cli_args.pop("command", None)
-        cli_args.pop("command_args", None)
-        config = Config(cli_args)
-        config.dump_config()
-        sys.exit(0)
-
+    handle_dump_config(parser)
     cli_args = vars(parser.parse_args())
 
     # Extract positional args and special flags (not part of FieldSpec)

--- a/src/con_duct/suite/main.py
+++ b/src/con_duct/suite/main.py
@@ -49,6 +49,7 @@ def main(argv: Optional[List[str]] = None) -> None:
     # Subcommand: pp
     parser_pp = subparsers.add_parser("pp", help="Pretty print a JSON log.")
     parser_pp.add_argument("file_path", help="JSON file to pretty print.")
+    # TODO(add env var and config)
     parser_pp.add_argument(
         "-H",
         "--humanize",
@@ -81,6 +82,7 @@ def main(argv: Optional[List[str]] = None) -> None:
         "ls",
         help="Print execution information for all matching runs.",
     )
+    # TODO(add env var DUCT_LS_FORMAT and config)
     parser_ls.add_argument(
         "-f",
         "--format",
@@ -89,6 +91,7 @@ def main(argv: Optional[List[str]] = None) -> None:
         help="Output format. TODO Fixme. 'auto' chooses 'pyout' if pyout library is installed,"
         " 'summaries' otherwise.",
     )
+    # TODO(add env var DUCT_LS_FIELDS and config)
     parser_ls.add_argument(
         "-F",
         "--fields",
@@ -104,12 +107,14 @@ def main(argv: Optional[List[str]] = None) -> None:
             "peak_rss",
         ],
     )
+    # TODO(already exists todo in __main__ we should use here too)
     parser_ls.add_argument(
         "--colors",
         action="store_true",
         default=os.getenv("DUCT_COLORS", False),
         help="Use colors in duct output.",
     )
+    # TODO(config: not now but we should consider adding
     parser_ls.add_argument(
         "paths",
         nargs="*",

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,0 +1,302 @@
+"""Tests for the Config class and validation functions."""
+
+import json
+import os
+import tempfile
+from unittest import mock
+import pytest
+from con_duct.__main__ import (
+    Config,
+    SessionMode,
+    bool_from_str,
+    build_parser,
+    handle_dump_config,
+    validate_positive,
+    validate_sample_report_interval,
+)
+
+
+class TestValidationFunctions:
+    """Test validation helper functions."""
+
+    def test_bool_from_str(self):
+        """Test string to boolean conversion."""
+        # True values
+        assert bool_from_str("true") is True
+        assert bool_from_str("True") is True
+        assert bool_from_str("TRUE") is True
+        assert bool_from_str("yes") is True
+        assert bool_from_str("Yes") is True
+        assert bool_from_str("1") is True
+
+        # False values
+        assert bool_from_str("false") is False
+        assert bool_from_str("False") is False
+        assert bool_from_str("FALSE") is False
+        assert bool_from_str("no") is False
+        assert bool_from_str("No") is False
+        assert bool_from_str("0") is False
+
+        # Invalid values
+        with pytest.raises(ValueError):
+            bool_from_str("maybe")
+        with pytest.raises(ValueError):
+            bool_from_str("2")
+        with pytest.raises(ValueError):
+            bool_from_str("")
+
+    def test_validate_positive(self):
+        """Test positive number validation."""
+        # Valid positive numbers
+        assert validate_positive(1) == 1
+        assert validate_positive(0.5) == 0.5
+        assert validate_positive(100) == 100
+
+        # Invalid non-positive numbers
+        with pytest.raises(ValueError, match="must be greater than 0"):
+            validate_positive(0)
+        with pytest.raises(ValueError, match="must be greater than 0"):
+            validate_positive(-1)
+        with pytest.raises(ValueError, match="must be greater than 0"):
+            validate_positive(-0.5)
+
+    @pytest.mark.parametrize(
+        "sample_interval,report_interval,should_raise,expected_message",
+        [
+            # Valid cases: report >= sample
+            (1.0, 5.0, False, None),
+            (2.0, 2.0, False, None),  # Equal is valid
+            (0.5, 1.0, False, None),
+            # Invalid cases: report < sample
+            (
+                5.0,
+                4.0,
+                True,
+                "report-interval must be greater than or equal to sample-interval",
+            ),
+            (
+                10.0,
+                5.0,
+                True,
+                "report-interval must be greater than or equal to sample-interval",
+            ),
+            (
+                3.5,
+                2.1,
+                True,
+                "report-interval must be greater than or equal to sample-interval",
+            ),
+        ],
+    )
+    def test_validate_sample_report_interval(
+        self, sample_interval, report_interval, should_raise, expected_message
+    ):
+        """Test sample/report interval validation."""
+        if should_raise:
+            with pytest.raises(ValueError, match=expected_message):
+                validate_sample_report_interval(sample_interval, report_interval)
+        else:
+            validate_sample_report_interval(
+                sample_interval, report_interval
+            )  # Should not raise
+
+
+class TestConfig:
+    """Test Config class functionality."""
+
+    def test_config_default_initialization(self):
+        """Test Config initialization with defaults."""
+        config = Config({})
+
+        # Check some default values
+        assert config.sample_interval == 0.5
+        assert config.report_interval == 60.0
+        assert config.capture_outputs == "all"
+        assert config.mode == SessionMode.NEW_SESSION
+        assert config.message == ""
+        assert config.log_level == "INFO"
+
+    def test_config_with_cli_args(self):
+        """Test Config initialization with CLI arguments."""
+        cli_args = {
+            "sample_interval": 2.0,
+            "report_interval": 120.0,
+            "message": "test message",
+            "log_level": "DEBUG",
+        }
+        config = Config(cli_args)
+
+        assert config.sample_interval == 2.0
+        assert config.report_interval == 120.0
+        assert config.message == "test message"
+        assert config.log_level == "DEBUG"
+
+    def test_config_with_env_vars(self):
+        """Test Config initialization with environment variables."""
+        with mock.patch.dict(
+            os.environ,
+            {
+                "DUCT_SAMPLE_INTERVAL": "3.0",
+                "DUCT_REPORT_INTERVAL": "180.0",
+                "DUCT_MESSAGE": "env message",
+                "DUCT_LOG_LEVEL": "WARNING",
+            },
+        ):
+            config = Config({})
+
+            assert config.sample_interval == 3.0
+            assert config.report_interval == 180.0
+            assert config.message == "env message"
+            assert config.log_level == "WARNING"
+
+    def test_config_precedence(self):
+        """Test configuration precedence: defaults < config file < env vars < CLI."""
+        # Create a temporary config file
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            config_data = {
+                "sample-interval": 10.0,
+                "report-interval": 100.0,
+                "message": "file message",
+                "log-level": "ERROR",
+            }
+            json.dump(config_data, f)
+            config_file = f.name
+
+        try:
+            # Test with config file
+            with mock.patch.dict(os.environ, {"DUCT_CONFIG": config_file}):
+                config = Config({})
+                assert config.sample_interval == 10.0
+                assert config.message == "file message"
+
+            # Test env vars override config file
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "DUCT_CONFIG": config_file,
+                    "DUCT_MESSAGE": "env message",
+                    "DUCT_SAMPLE_INTERVAL": "15.0",
+                },
+            ):
+                config = Config({})
+                assert config.sample_interval == 15.0
+                assert config.message == "env message"
+
+            # Test CLI args override everything
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "DUCT_CONFIG": config_file,
+                    "DUCT_MESSAGE": "env message",
+                },
+            ):
+                cli_args = {"message": "cli message", "sample_interval": 20.0}
+                config = Config(cli_args)
+                assert config.sample_interval == 20.0
+                assert config.message == "cli message"
+
+        finally:
+            os.unlink(config_file)
+
+    def test_config_invalid_json_file(self):
+        """Test Config handles invalid JSON files gracefully."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            f.write("not valid json")
+            config_file = f.name
+
+        try:
+            with mock.patch.dict(os.environ, {"DUCT_CONFIG": config_file}):
+                with pytest.raises(SystemExit):
+                    Config({})
+        finally:
+            os.unlink(config_file)
+
+    def test_config_nonexistent_file(self):
+        """Test Config handles nonexistent config files gracefully."""
+        # Nonexistent file in DUCT_CONFIG should cause error
+        with mock.patch.dict(os.environ, {"DUCT_CONFIG": "/nonexistent/config.json"}):
+            # Should log warning but not fail (uses defaults)
+            config = Config({})
+            assert config.sample_interval == 0.5  # default value
+
+    def test_config_dump(self, capsys):
+        """Test Config.dump_config() method."""
+        config = Config({"message": "test"})
+        config.dump_config()
+
+        captured = capsys.readouterr()
+        output = json.loads(captured.out)
+
+        assert "values" in output
+        assert "sources" in output
+        assert output["values"]["message"] == "test"
+        assert "CLI:" in output["sources"]["message"]
+
+
+class TestHandleDumpConfig:
+    """Test handle_dump_config function."""
+
+    def test_handle_dump_config_exits(self):
+        """Test that --dump-config causes early exit."""
+        parser = build_parser()
+
+        with pytest.raises(SystemExit) as exc_info:
+            with mock.patch("sys.argv", ["duct", "--dump-config", "echo", "test"]):
+                handle_dump_config(parser)
+
+        assert exc_info.value.code == 0
+
+    def test_handle_dump_config_no_flag(self):
+        """Test that without --dump-config, function returns normally."""
+        parser = build_parser()
+
+        with mock.patch("sys.argv", ["duct", "echo", "test"]):
+            result = handle_dump_config(parser)
+            assert result is None  # Should return without raising
+
+
+class TestBuildParser:
+    """Test build_parser function."""
+
+    def test_build_parser_creates_parser(self):
+        """Test that build_parser creates a valid ArgumentParser."""
+        parser = build_parser()
+
+        # Check parser has expected arguments
+        args = parser.parse_args(["echo", "test"])
+        assert args.command == "echo"
+        assert args.command_args == ["test"]
+
+    def test_build_parser_includes_all_field_specs(self):
+        """Test that parser includes all FieldSpec arguments."""
+        parser = build_parser()
+
+        # Test various arguments are accepted
+        args = parser.parse_args(
+            [
+                "--output-prefix",
+                "/tmp/test",
+                "--sample-interval",
+                "2",
+                "--report-interval",
+                "10",
+                "--capture-outputs",
+                "none",
+                "--mode",
+                "current-session",
+                "-m",
+                "test message",
+                "--log-level",
+                "DEBUG",
+                "echo",
+                "hello",
+            ]
+        )
+
+        assert args.output_prefix == "/tmp/test"
+        assert args.sample_interval == 2.0
+        assert args.report_interval == 10.0
+        assert args.capture_outputs == "none"
+        assert str(args.mode) == "current-session"
+        assert args.message == "test message"
+        assert args.log_level == "DEBUG"

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -5,13 +5,7 @@ import os
 import tempfile
 from unittest import mock
 import pytest
-from con_duct.__main__ import (
-    FIELD_SPECS,
-    Config,
-    SessionMode,
-    build_parser,
-    handle_dump_config,
-)
+from con_duct.__main__ import FIELD_SPECS, Config, build_parser, handle_dump_config
 
 
 class TestValidationFunctions:
@@ -104,15 +98,17 @@ class TestConfig:
 
     def test_config_default_initialization(self):
         """Test Config initialization with defaults."""
-        config = Config({})
+        # Clear env vars that conftest.py sets to test true defaults
+        with mock.patch.dict(os.environ, {}, clear=True):
+            config = Config({})
 
-        # Check some default values
-        assert config.sample_interval == 0.5
-        assert config.report_interval == 60.0
-        assert config.capture_outputs == "all"
-        assert config.mode == SessionMode.NEW_SESSION
-        assert config.message == ""
-        assert config.log_level == "INFO"
+            # Check some default values
+            assert config.sample_interval == FIELD_SPECS["sample_interval"].default
+            assert config.report_interval == FIELD_SPECS["report_interval"].default
+            assert config.capture_outputs == FIELD_SPECS["capture_outputs"].default
+            assert config.mode == FIELD_SPECS["mode"].default
+            assert config.message == FIELD_SPECS["message"].default
+            assert config.log_level == FIELD_SPECS["log_level"].default
 
     def test_config_with_cli_args(self):
         """Test Config initialization with CLI arguments."""
@@ -232,10 +228,10 @@ class TestConfig:
         captured = capsys.readouterr()
         output = json.loads(captured.out)
 
-        assert "values" in output
-        assert "sources" in output
-        assert output["values"]["message"] == "test"
-        assert "CLI:" in output["sources"]["message"]
+        assert "message" in output
+        assert output["message"]["value"] == "test"
+        assert "CLI:" in output["message"]["source"]
+        assert output["message"]["type"] == "str"
 
 
 class TestHandleDumpConfig:

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -5,15 +5,7 @@ import os
 import tempfile
 from unittest import mock
 import pytest
-from con_duct.__main__ import (
-    Config,
-    SessionMode,
-    bool_from_str,
-    build_parser,
-    handle_dump_config,
-    validate_positive,
-    validate_sample_report_interval,
-)
+from con_duct.__main__ import Config, SessionMode, build_parser, handle_dump_config
 
 
 class TestValidationFunctions:
@@ -22,43 +14,43 @@ class TestValidationFunctions:
     def test_bool_from_str(self):
         """Test string to boolean conversion."""
         # True values
-        assert bool_from_str("true") is True
-        assert bool_from_str("True") is True
-        assert bool_from_str("TRUE") is True
-        assert bool_from_str("yes") is True
-        assert bool_from_str("Yes") is True
-        assert bool_from_str("1") is True
+        assert Config.bool_from_str("true") is True
+        assert Config.bool_from_str("True") is True
+        assert Config.bool_from_str("TRUE") is True
+        assert Config.bool_from_str("yes") is True
+        assert Config.bool_from_str("Yes") is True
+        assert Config.bool_from_str("1") is True
 
         # False values
-        assert bool_from_str("false") is False
-        assert bool_from_str("False") is False
-        assert bool_from_str("FALSE") is False
-        assert bool_from_str("no") is False
-        assert bool_from_str("No") is False
-        assert bool_from_str("0") is False
+        assert Config.bool_from_str("false") is False
+        assert Config.bool_from_str("False") is False
+        assert Config.bool_from_str("FALSE") is False
+        assert Config.bool_from_str("no") is False
+        assert Config.bool_from_str("No") is False
+        assert Config.bool_from_str("0") is False
 
         # Invalid values
         with pytest.raises(ValueError):
-            bool_from_str("maybe")
+            Config.bool_from_str("maybe")
         with pytest.raises(ValueError):
-            bool_from_str("2")
+            Config.bool_from_str("2")
         with pytest.raises(ValueError):
-            bool_from_str("")
+            Config.bool_from_str("")
 
     def test_validate_positive(self):
         """Test positive number validation."""
         # Valid positive numbers
-        assert validate_positive(1) == 1
-        assert validate_positive(0.5) == 0.5
-        assert validate_positive(100) == 100
+        assert Config.validate_positive(1) == 1
+        assert Config.validate_positive(0.5) == 0.5
+        assert Config.validate_positive(100) == 100
 
         # Invalid non-positive numbers
         with pytest.raises(ValueError, match="must be greater than 0"):
-            validate_positive(0)
+            Config.validate_positive(0)
         with pytest.raises(ValueError, match="must be greater than 0"):
-            validate_positive(-1)
+            Config.validate_positive(-1)
         with pytest.raises(ValueError, match="must be greater than 0"):
-            validate_positive(-0.5)
+            Config.validate_positive(-0.5)
 
     @pytest.mark.parametrize(
         "sample_interval,report_interval,should_raise,expected_message",
@@ -94,9 +86,9 @@ class TestValidationFunctions:
         """Test sample/report interval validation."""
         if should_raise:
             with pytest.raises(ValueError, match=expected_message):
-                validate_sample_report_interval(sample_interval, report_interval)
+                Config.validate_sample_report_interval(sample_interval, report_interval)
         else:
-            validate_sample_report_interval(
+            Config.validate_sample_report_interval(
                 sample_interval, report_interval
             )  # Should not raise
 


### PR DESCRIPTION
@yarikoptic this is a WIP, but non-draft since this could use design review before continuing into the weeds

- Fixes #279

TODO (adjust) At the high level:
 - startup using `DEFAULT_CONFIG` defined in `__main__`
 - retrieve `-C --config` first if passed
 - load in DEFAULT_CONFIG and then override from each file in order (colon separated)
 - use environment variables if they are present (this is also reflected in the config object
 - the config is then used by the CLI to set default values, which the user can override

NOTE! If you use config files, duct --help will show options' default values to be the ones specified in the config, which I think makes sense but a little unusual.

TODO:
 - [ ] fix tests 
 - [ ] add tests
 - [ ] add to con-duct CLI
 - [ ] make sure -C --config shows up in helptext (currently not)
 - [ ] reconsider behavior "fail if user-provided paths DNE, but pass if default paths DNE" maybe just try and proceed with DEBUG
 - [ ] hand-test thoroughly
 - [ ] optional: use `config` everywhere instead of `args`. IMO nicer usage, but uglier code and a substantially large patch so not worth it
 - [ ] optional: add `con-duct init-conf` to scaffold a config.json file with all default values.