### PR TITLE
Add --reverse option to con-duct ls command

### DIFF
--- a/src/con_duct/suite/ls.py
+++ b/src/con_duct/suite/ls.py
@@ -230,6 +230,10 @@ def ls(args: argparse.Namespace) -> int:
     run_data_raw = load_duct_runs(info_files, args.eval_filter)
     output_rows = process_run_data(run_data_raw, args.fields, formatter)
 
+    # Apply reverse ordering if requested
+    if args.reverse:
+        output_rows = list(reversed(output_rows))
+
     if args.format == "summaries":
         for row in output_rows:
             for col, value in row.items():

--- a/src/con_duct/suite/main.py
+++ b/src/con_duct/suite/main.py
@@ -125,6 +125,12 @@ def main(argv: Optional[List[str]] = None) -> None:
         "Example: --eval-filter \"filter_this=='yes'\" filters entries where 'filter_this' is 'yes'. "
         "You can use 're' for regex operations (e.g., --eval-filter \"re.search('2025.02.09.*', prefix)\").",
     )
+    parser_ls.add_argument(
+        "-r",
+        "--reverse",
+        action="store_true",
+        help="List entries in reverse order (most recent on top).",
+    )
     parser_ls.set_defaults(func=ls)
 
     args = parser.parse_args(argv)

--- a/test/test_ls.py
+++ b/test/test_ls.py
@@ -99,6 +99,38 @@ def test_ensure_compliant_schema_ignores_unexpected_future_version() -> None:
     assert "working_directory" not in info["execution_summary"]
 
 
+def test_process_run_data_with_reverse() -> None:
+    run_data = [
+        {
+            "prefix": "/test/path1",
+            "exit_code": 0,
+            "wall_clock_time": 0.1,
+        },
+        {
+            "prefix": "/test/path2",
+            "exit_code": 1,
+            "wall_clock_time": 0.2,
+        },
+        {
+            "prefix": "/test/path3",
+            "exit_code": 0,
+            "wall_clock_time": 0.3,
+        },
+    ]
+    formatter = SummaryFormatter(enable_colors=False)
+    result = process_run_data(run_data, ["exit_code", "wall_clock_time"], formatter)
+    # Original order
+    assert result[0]["prefix"] == "/test/path1"
+    assert result[1]["prefix"] == "/test/path2"
+    assert result[2]["prefix"] == "/test/path3"
+
+    # Test reverse order
+    reversed_result = list(reversed(result))
+    assert reversed_result[0]["prefix"] == "/test/path3"
+    assert reversed_result[1]["prefix"] == "/test/path2"
+    assert reversed_result[2]["prefix"] == "/test/path1"
+
+
 def test_load_duct_runs_handles_empty_json_files(
     caplog: pytest.LogCaptureFixture,
 ) -> None:

--- a/test/test_suite.py
+++ b/test/test_suite.py
@@ -464,6 +464,7 @@ class TestLS(unittest.TestCase):
                 fields=["prefix", "schema_version"],
                 eval_filter=None,
                 format=fmt,
+                reverse=False,
                 func=ls,
             )
         buf = StringIO()
@@ -495,6 +496,7 @@ class TestLS(unittest.TestCase):
             fields=["prefix", "schema_version"],
             eval_filter="filter_this=='yes'",
             format="summaries",
+            reverse=False,
             func=ls,
         )
         result = self._run_ls(paths, "summaries", args)
@@ -603,3 +605,39 @@ class TestLS(unittest.TestCase):
         # pyout header
         assert "PREFIX" in result
         assert os.path.join(self.temp_dir.name, "file1_") in result
+
+    def test_ls_reverse_order(self) -> None:
+        """Test that --reverse flag reverses the order of results."""
+        paths = ["file1_info.json", "file2_info.json"]
+
+        # Get normal order
+        args_normal = argparse.Namespace(
+            paths=[os.path.join(self.temp_dir.name, path) for path in paths],
+            colors=False,
+            fields=["prefix", "schema_version"],
+            eval_filter=None,
+            format="json",
+            reverse=False,
+            func=ls,
+        )
+        result_normal = self._run_ls(paths, "json", args_normal)
+        parsed_normal = json.loads(result_normal)
+
+        # Get reversed order
+        args_reverse = argparse.Namespace(
+            paths=[os.path.join(self.temp_dir.name, path) for path in paths],
+            colors=False,
+            fields=["prefix", "schema_version"],
+            eval_filter=None,
+            format="json",
+            reverse=True,
+            func=ls,
+        )
+        result_reverse = self._run_ls(paths, "json", args_reverse)
+        parsed_reverse = json.loads(result_reverse)
+
+        # Check that the order is actually reversed
+        assert len(parsed_normal) == 2
+        assert len(parsed_reverse) == 2
+        assert parsed_normal[0]["prefix"] == parsed_reverse[1]["prefix"]
+        assert parsed_normal[1]["prefix"] == parsed_reverse[0]["prefix"]


### PR DESCRIPTION
The -r/--reverse flag lists entries in reverse order, showing the most recent entries on top. This is useful for quickly viewing the latest execution results when there are many entries.

🤖 Generated with [Claude Code](https://claude.ai/code)