### PR TITLE
Revert mergify integration (PRs #270 and #271)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -67,12 +67,9 @@ jobs:
           python -m pip install --upgrade --upgrade-strategy=eager tox
           sudo apt-get install -y libjpeg-dev
 
-      - name: Run tests with coverage and mergify reporting
+      - name: Run tests with coverage
         if: matrix.toxenv == 'py'
-        env:
-          MERGIFY_TOKEN: ${{ secrets.MERGIFY_CIINSIGHTS_TOKEN }}
-        run: |
-          tox -e pyci -- -vv --cov-report=xml
+        run: tox -e py -- -vv --cov-report=xml
 
       - name: Run generic tests
         if: matrix.toxenv != 'py'

--- a/tox.ini
+++ b/tox.ini
@@ -14,16 +14,6 @@ commands =
     pytest {posargs} test
 passenv = USER
 
-[testenv:pyci]
-deps =
-    {[testenv]deps}
-    pytest-mergify
-passenv =
-    {[testenv]passenv}
-    CI
-    GITHUB_*
-    MERGIFY_TOKEN
-
 [testenv:lint]
 deps =
     flake8


### PR DESCRIPTION
This reverts commits:
- b57b94c (PR #271): Additional mergify configuration
- d3b711c (PR #270): Initial mergify support

We never got Mergify working as expected, so removing it.