### PR TITLE
pin rpds-py so pypy 3.10 tests pass

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -60,6 +60,8 @@ all =
     matplotlib
     PyYAML
     pyout
+    # Pin rpds-py to support PyPy 3.10 - https://github.com/con/duct/issues/330
+    rpds-py<0.28.0
 
 
 [options.entry_points]


### PR DESCRIPTION
rpds-py is a dependency of jsonschema, which is a dependency of pyout, which is optional. 

rpds-py dropped pypy3.10 support last week.

Fixes https://github.com/con/duct/issues/330