### PR TITLE
Use jsonl suffix and centralize json loading

### DIFF
--- a/src/con_duct/cli.py
+++ b/src/con_duct/cli.py
@@ -246,7 +246,7 @@ def _create_plot_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         add_help=False,  # help provided by child
     )
-    parser.add_argument("file_path", help="duct-produced usage.json file.")
+    parser.add_argument("file_path", help="duct-produced usage file.")
     parser.add_argument(
         "-o",
         "--output",

--- a/src/con_duct/duct_main.py
+++ b/src/con_duct/duct_main.py
@@ -36,7 +36,8 @@ ENV_PREFIXES = ("PBS_", "SLURM_", "OSG")
 SUFFIXES = {
     "stdout": "stdout",
     "stderr": "stderr",
-    "usage": "usage.json",
+    "usage": "usage.jsonl",
+    "usage_legacy": "usage.json",
     "info": "info.json",
 }
 EXECUTION_SUMMARY_FORMAT = (

--- a/src/con_duct/json_utils.py
+++ b/src/con_duct/json_utils.py
@@ -1,0 +1,34 @@
+"""Centralized JSON file type detection and loading for duct."""
+
+from __future__ import annotations
+import json
+from typing import Any
+from con_duct.duct_main import SUFFIXES
+
+# Suffixes that use JSON Lines format
+JSONL_SUFFIXES = (SUFFIXES["usage"], SUFFIXES["usage_legacy"])
+
+
+def is_jsonl_file(path: str) -> bool:
+    """Check if path is a JSON Lines file."""
+    if any(path.endswith(s) for s in JSONL_SUFFIXES):
+        return True
+    return path.endswith(".jsonl")
+
+
+def is_info_file(path: str) -> bool:
+    """Check if path is a duct info file (standard JSON)."""
+    return path.endswith(SUFFIXES["info"])
+
+
+def load_usage_file(path: str) -> list[dict[str, Any]]:
+    """Load a duct usage file (JSON Lines format)."""
+    with open(path, "r") as f:
+        return [json.loads(line) for line in f if line.strip()]
+
+
+def load_info_file(path: str) -> dict[str, Any]:
+    """Load a duct info file (standard JSON)."""
+    with open(path, "r") as f:
+        result: dict[str, Any] = json.load(f)
+        return result

--- a/src/con_duct/ls.py
+++ b/src/con_duct/ls.py
@@ -7,6 +7,7 @@ import re
 from types import ModuleType
 from typing import Any, Dict, List, Optional
 from con_duct.duct_main import DUCT_OUTPUT_PREFIX, SummaryFormatter, __schema_version__
+from con_duct.json_utils import is_info_file
 from con_duct.utils import parse_version
 
 try:
@@ -226,7 +227,7 @@ def ls(args: argparse.Namespace) -> int:
     formatter = SummaryFormatter(
         enable_colors=False if args.format == "pyout" else args.colors
     )
-    info_files = [path for path in args.paths if path.endswith("info.json")]
+    info_files = [path for path in args.paths if is_info_file(path)]
     run_data_raw = load_duct_runs(info_files, args.eval_filter)
     output_rows = process_run_data(run_data_raw, args.fields, formatter)
 

--- a/src/con_duct/plot.py
+++ b/src/con_duct/plot.py
@@ -4,6 +4,7 @@ import json
 import logging
 from pathlib import Path
 from typing import Any, List, Optional, Tuple
+from con_duct.json_utils import is_info_file, load_info_file, load_usage_file
 
 lgr = logging.getLogger(__name__)
 
@@ -78,21 +79,17 @@ def matplotlib_plot(args: argparse.Namespace) -> int:
 
     # Handle info.json files by determining the path to usage file
     file_path = Path(args.file_path)
-    if file_path.name.endswith("info.json"):
+    if is_info_file(str(file_path)):
         try:
-            with open(file_path, "r") as info_file:
-                info_data = json.load(info_file)
-                rel_usage_path = Path(info_data["output_paths"]["usage"])
-                file_path = file_path.with_name(rel_usage_path.name)
+            info_data = load_info_file(str(file_path))
+            rel_usage_path = Path(info_data["output_paths"]["usage"])
+            file_path = file_path.with_name(rel_usage_path.name)
         except (FileNotFoundError, KeyError, json.JSONDecodeError) as e:
             lgr.error("Error reading info file %s: %s", args.file_path, e)
             return 1
 
-    data = []
     try:
-        with open(file_path, "r") as file:
-            for line in file:
-                data.append(json.loads(line))
+        data = load_usage_file(str(file_path))
     except FileNotFoundError:
         lgr.error("File %s was not found.", file_path)
         return 1

--- a/src/con_duct/pprint_json.py
+++ b/src/con_duct/pprint_json.py
@@ -4,6 +4,7 @@ import logging
 from pprint import pprint
 from typing import Any
 from con_duct.duct_main import SummaryFormatter
+from con_duct.json_utils import is_jsonl_file, load_info_file, load_usage_file
 
 lgr = logging.getLogger(__name__)
 
@@ -66,16 +67,13 @@ def pprint_json(args: argparse.Namespace) -> int:
     """
     Prints the contents of a JSON file using pprint.
 
-    Handles both standard JSON files and JSON Lines (usage.json) files.
+    Handles both standard JSON files and JSON Lines (usage.jsonl) files.
     """
-    is_usage_file = args.file_path.endswith("usage.json")
-
     try:
-        with open(args.file_path, "r") as file:
-            if is_usage_file:
-                data = [json.loads(line) for line in file if line.strip()]
-            else:
-                data = json.load(file)
+        if is_jsonl_file(args.file_path):
+            data: Any = load_usage_file(args.file_path)
+        else:
+            data = load_info_file(args.file_path)
 
         if args.humanize:
             formatter = SummaryFormatter()

--- a/test/test_e2e.py
+++ b/test/test_e2e.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import subprocess
 import time
 import pytest
+from con_duct.duct_main import SUFFIXES
 
 TEST_SCRIPT_DIR = Path(__file__).with_name("data")
 
@@ -23,7 +24,7 @@ def test_spawn_children(temp_output_dir: str, mode: str, num_children: int) -> N
     command = f"duct -q --s-i 0.001 --r-i 0.01 -p {duct_prefix} {script_path} {mode} {num_children} {dur}"
     subprocess.check_output(command, shell=True)
 
-    with open(f"{duct_prefix}usage.json") as usage_file:
+    with open(f"{duct_prefix}{SUFFIXES['usage']}") as usage_file:
         all_samples = [json.loads(line) for line in usage_file]
 
     # Only count the child sleep processes
@@ -48,8 +49,8 @@ def test_session_modes(temp_output_dir: str, session_mode: str) -> None:
     subprocess.check_output(command, shell=True)
 
     # Check that log files were created
-    usage_file = Path(f"{duct_prefix}usage.json")
-    info_file = Path(f"{duct_prefix}info.json")
+    usage_file = Path(f"{duct_prefix}{SUFFIXES['usage']}")
+    info_file = Path(f"{duct_prefix}{SUFFIXES['info']}")
 
     assert usage_file.exists(), f"Usage file not created for {session_mode} mode"
     assert info_file.exists(), f"Info file not created for {session_mode} mode"
@@ -106,10 +107,10 @@ def test_session_mode_behavior_difference(temp_output_dir: str) -> None:
         )
 
         # Read usage data from both
-        with open(f"{new_session_prefix}usage.json") as f:
+        with open(f"{new_session_prefix}{SUFFIXES['usage']}") as f:
             new_session_samples = [json.loads(line) for line in f]
 
-        with open(f"{current_session_prefix}usage.json") as f:
+        with open(f"{current_session_prefix}{SUFFIXES['usage']}") as f:
             current_session_samples = [json.loads(line) for line in f]
 
         # Check for our unique background process

--- a/test/test_execution.py
+++ b/test/test_execution.py
@@ -176,7 +176,7 @@ def test_run_less_than_report_interval(temp_output_dir: str) -> None:
         )
         == 0
     )
-    # Specifically we need to assert that usage.json gets written anyway.
+    # Specifically we need to assert that usage file gets written anyway.
     assert_expected_files(temp_output_dir)
 
 

--- a/test/test_json_utils.py
+++ b/test/test_json_utils.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+import json
+from pathlib import Path
+import pytest
+from con_duct.duct_main import SUFFIXES
+from con_duct.json_utils import (
+    JSONL_SUFFIXES,
+    is_info_file,
+    is_jsonl_file,
+    load_info_file,
+    load_usage_file,
+)
+
+
+class TestIsJsonlFile:
+    def test_usage_jsonl(self) -> None:
+        assert is_jsonl_file(f"prefix_{SUFFIXES['usage']}")
+
+    def test_usage_legacy(self) -> None:
+        assert is_jsonl_file(f"prefix_{SUFFIXES['usage_legacy']}")
+
+    def test_generic_jsonl(self) -> None:
+        assert is_jsonl_file("anything.jsonl")
+
+    def test_info_json_is_not_jsonl(self) -> None:
+        assert not is_jsonl_file(f"prefix_{SUFFIXES['info']}")
+
+    def test_random_json_is_not_jsonl(self) -> None:
+        assert not is_jsonl_file("something.json")
+
+
+class TestIsInfoFile:
+    def test_info_file(self) -> None:
+        assert is_info_file(f"prefix_{SUFFIXES['info']}")
+
+    def test_usage_is_not_info(self) -> None:
+        assert not is_info_file(f"prefix_{SUFFIXES['usage']}")
+
+    def test_random_json_is_not_info(self) -> None:
+        assert not is_info_file("something.json")
+
+
+class TestLoadUsageFile:
+    def test_load_usage_file(self, tmp_path: Path) -> None:
+        usage_file = tmp_path / SUFFIXES["usage"]
+        usage_file.write_text(
+            '{"timestamp": "2024-01-01", "totals": {"rss": 100}}\n'
+            '{"timestamp": "2024-01-02", "totals": {"rss": 200}}\n'
+        )
+        data = load_usage_file(str(usage_file))
+        assert len(data) == 2
+        assert data[0]["totals"]["rss"] == 100
+        assert data[1]["totals"]["rss"] == 200
+
+    def test_load_empty_usage_file(self, tmp_path: Path) -> None:
+        usage_file = tmp_path / SUFFIXES["usage"]
+        usage_file.write_text("")
+        data = load_usage_file(str(usage_file))
+        assert data == []
+
+    def test_load_usage_file_skips_blank_lines(self, tmp_path: Path) -> None:
+        usage_file = tmp_path / SUFFIXES["usage"]
+        usage_file.write_text('{"a": 1}\n\n{"b": 2}\n')
+        data = load_usage_file(str(usage_file))
+        assert len(data) == 2
+
+
+class TestLoadInfoFile:
+    def test_load_info_file(self, tmp_path: Path) -> None:
+        info_file = tmp_path / SUFFIXES["info"]
+        info_file.write_text('{"command": "sleep 1", "exit_code": 0}')
+        data = load_info_file(str(info_file))
+        assert data["command"] == "sleep 1"
+        assert data["exit_code"] == 0
+
+    def test_load_info_file_not_found(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError):
+            load_info_file(str(tmp_path / "nonexistent.json"))
+
+    def test_load_info_file_invalid_json(self, tmp_path: Path) -> None:
+        info_file = tmp_path / SUFFIXES["info"]
+        info_file.write_text("not valid json")
+        with pytest.raises(json.JSONDecodeError):
+            load_info_file(str(info_file))
+
+
+class TestJsonlSuffixes:
+    def test_contains_current_and_legacy(self) -> None:
+        assert SUFFIXES["usage"] in JSONL_SUFFIXES
+        assert SUFFIXES["usage_legacy"] in JSONL_SUFFIXES

--- a/test/test_schema.py
+++ b/test/test_schema.py
@@ -2,6 +2,7 @@ import json
 import os
 from pathlib import Path
 from utils import run_duct_command
+from con_duct.duct_main import SUFFIXES
 from con_duct.ls import LS_FIELD_CHOICES, _flatten_dict
 
 
@@ -20,11 +21,11 @@ def test_info_fields(temp_output_dir: str) -> None:
         )
         == 0
     )
-    os.remove(Path(temp_output_dir, "stdout"))
-    os.remove(Path(temp_output_dir, "stderr"))
-    os.remove(Path(temp_output_dir, "usage.json"))
+    os.remove(Path(temp_output_dir, SUFFIXES["stdout"]))
+    os.remove(Path(temp_output_dir, SUFFIXES["stderr"]))
+    os.remove(Path(temp_output_dir, SUFFIXES["usage"]))
 
-    info_file = Path(temp_output_dir, "info.json")
+    info_file = Path(temp_output_dir, SUFFIXES["info"])
     actual_info_schema = _flatten_dict(json.loads(info_file.read_text())).keys()
     os.remove(info_file)
 


### PR DESCRIPTION
Solves 2 issues: 
 - Fixes https://github.com/con/duct/issues/342
 - Fixes https://github.com/con/duct/issues/339
 
 Changes:
- Change usage file extension from .json to .jsonl for new runs
- Add usage_legacy suffix for backward compatibility with existing files
- Create json_utils.py with centralized file type detection and loading
- Update pprint, plot, ls to use json_utils functions
- Update tests to use SUFFIXES constants instead of hardcoded strings