### PR TITLE
pin pyparsing for oldestdeps environment

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -53,7 +53,9 @@ deps =
 commands =
     # numpy<2 required because matplotlib 3.5 was compiled against numpy 1.x
     # numpy>=1.21.3 is first with Python 3.10 wheels
-    uv pip install --resolution lowest-direct -e .[all] "numpy>=1.21.3,<2"
+    # pyparsing<3.3 required because 3.3.0 emits DeprecationWarnings for old method
+    # names (enablePackrat) that matplotlib 3.5 still uses
+    uv pip install --resolution lowest-direct -e .[all] "numpy>=1.21.3,<2" "pyparsing>=3.0,<3.3"
     pytest {posargs} test
 
 [pytest]


### PR DESCRIPTION
Fixes https://github.com/con/duct/issues/352

pyparsing 3.3.0 (released Dec 22) emits DeprecationWarnings for old method names like enablePackrat(). matplotlib 3.5 still uses these old names. Since tox.ini has filterwarnings = error, these warnings become errors that break the matplotlib import.

Pin pyparsing>=3.0,<3.3 to use the last compatible version.