### PR TITLE
filter pyparsing deprecation warnings instead of pinning

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -61,7 +61,7 @@ addopts = --cov=con_duct --no-cov-on-fail
 filterwarnings =
     error
     # matplotlib 3.5 uses deprecated pyparsing API (enablePackrat -> enable_packrat)
-    ignore:.*deprecated.*:DeprecationWarning:matplotlib.*
+    ignore:'enablePackrat' deprecated:DeprecationWarning:matplotlib._mathtext
 norecursedirs = test/data
 
 [coverage:run]


### PR DESCRIPTION
Fixes https://github.com/con/duct/issues/354

Replace the pyparsing version pin with a filterwarnings ignore for matplotlib's deprecated pyparsing API usage. This approach allows detecting new issues from dependency updates while suppressing known-acceptable warnings.

Supersedes the approach in #353.