### PR TITLE
Increase wait time on rerun for flakey tests

### DIFF
--- a/test/duct_main/test_execution.py
+++ b/test/duct_main/test_execution.py
@@ -230,10 +230,14 @@ def _runner_for_signal_int(temp_output_dir: str, fail_time: float | None) -> int
     )
 
 
+@pytest.mark.flaky(reruns=5)
 @pytest.mark.parametrize("fail_time", [None, 0, 10, -1, -3.14])
-def test_signal_int(temp_output_dir: str, fail_time: float | None) -> None:
-
-    wait_time = 0.3
+def test_signal_int(
+    request: pytest.FixtureRequest, temp_output_dir: str, fail_time: float | None
+) -> None:
+    # Scale wait time on retries to handle slow CI runners (PyPy, Mac)
+    attempt = getattr(request.node, "execution_count", 1)
+    wait_time = 0.2 * attempt
     proc = multiprocessing.Process(
         target=_runner_for_signal_int, args=(temp_output_dir, fail_time)
     )
@@ -266,10 +270,14 @@ def _runner_for_signal_kill(temp_output_dir: str, fail_time: float | None) -> in
     return run_duct_command([script_path], output_prefix=temp_output_dir, **kws)
 
 
+@pytest.mark.flaky(reruns=5)
 @pytest.mark.parametrize("fail_time", [None, 0, 10, -1, -3.14])
-def test_signal_kill(temp_output_dir: str, fail_time: float | None) -> None:
-
-    wait_time = 0.6
+def test_signal_kill(
+    request: pytest.FixtureRequest, temp_output_dir: str, fail_time: float | None
+) -> None:
+    # Scale wait time on retries to handle slow CI runners (PyPy, Mac)
+    attempt = getattr(request.node, "execution_count", 1)
+    wait_time = 0.2 * attempt
     proc = multiprocessing.Process(
         target=_runner_for_signal_kill, args=(temp_output_dir, fail_time)
     )


### PR DESCRIPTION
Hopefully Fixes: https://github.com/con/duct/issues/190

Signal tests fail sometimes, probably due to a race condition. On slow startup on some CI systems (I've never seen locally) the signal could be sent before the signal handler is registered. If that is whats happening, the test fails, and on the next rerun the wait time inceases.

With this retry logic, it seems worth also dropping the wait time a little bit.

@CodyCBakerPhD this will hopefully solve a lot of the flake you've been seeing.
@candleindark tagging you too since you recently dug into signal handling :) 