### PR TITLE
Improve the `_str2bool()` function

### DIFF
--- a/src/con_duct/duct_main.py
+++ b/src/con_duct/duct_main.py
@@ -49,8 +49,24 @@ def _str2bool(val: str) -> bool:
         raise ValueError(f"invalid truth value {val!r}")
 
 
+# Determine whether to ignore Intel macOS warning by checking environment variable
+try:
+    ignore_intel_warning = _str2bool(val=os.getenv("DUCT_IGNORE_INTEL_WARNING", "0"))
+except ValueError:
+    message = "\n".join(
+        [
+            "The value of the environment variable `DUCT_IGNORE_INTEL_WARNING` "
+            "is invalid.",
+            "Please set it to one of the following values or their uppercase variants:",
+            "- True values: " + ", ".join(f"'{v}'" for v in _true_expressions),
+            "- False values: " + ", ".join(f"'{v}'" for v in _false_expressions),
+            "",
+        ]
+    )
+    ignore_intel_warning = False
+
 is_mac_intel = sys.platform == "darwin" and os.uname().machine == "x86_64"
-if is_mac_intel and not _str2bool(val=os.getenv("DUCT_IGNORE_INTEL_WARNING", "0")):
+if is_mac_intel and not ignore_intel_warning:
     message = (
         "Detected system macOS running on intel architecture - "
         "duct may experience issues with sampling and signal handling.\n\n"


### PR DESCRIPTION
This PR improve the `_str2bool()` function to address its issues.

Before the proposed change in this PR, `_str2bool()` has the following issues.

- It is annotated to return an optional type, but it never returns `None`
- It is name `_str2bool`, but it handles input other than `str`. This behavior not needed and make it counterintuitive.
- It raises a `ValueError` when the input is not a valid string representation of a truth value, and such a raised error is not handled properly in the usage of the `_str2bool()` function. (I.e. if the `DUCT_IGNORE_INTEL_WARNING` env variable is set to "hello", the program exits with a `ValueError` exception instead of the warning about setting the `DUCT_IGNORE_INTEL_WARNING` env var.

This PR eliminates the above issues and adds documentation.