### PR TITLE
Allow e2e tests to use configurable executable

### DIFF
--- a/test/duct_main/test_e2e.py
+++ b/test/duct_main/test_e2e.py
@@ -19,7 +19,7 @@ _DUCT_EXECUTABLES = os.environ.get("DUCT_TEST_EXECUTABLES", "duct,con-duct run")
 @pytest.fixture(params=_DUCT_EXECUTABLES)
 def duct_cmd(request: pytest.FixtureRequest) -> str:
     """Fixture that parametrizes tests to run with different duct entry points."""
-    return request.param
+    return str(request.param)
 
 
 def test_sanity(temp_output_dir: str, duct_cmd: str) -> None:

--- a/test/duct_main/test_e2e.py
+++ b/test/duct_main/test_e2e.py
@@ -11,9 +11,10 @@ from con_duct.duct_main import SUFFIXES
 SYSTEM = platform.system()
 TEST_SCRIPT_DIR = Path(__file__).parent.parent / "data"
 # Allow overriding the duct executable for testing external builds (e.g., PyInstaller)
-_DUCT_EXECUTABLES = os.environ.get("DUCT_TEST_EXECUTABLES", "duct,con-duct run").split(
-    ","
-)
+_DUCT_EXECUTABLES = [
+    exe.strip()
+    for exe in os.environ.get("DUCT_TEST_EXECUTABLES", "duct,con-duct run").split(",")
+]
 
 
 @pytest.fixture(params=_DUCT_EXECUTABLES)

--- a/test/duct_main/test_e2e.py
+++ b/test/duct_main/test_e2e.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 import json
+import os
 from pathlib import Path
 import platform
 import subprocess
@@ -9,21 +10,36 @@ from con_duct.duct_main import SUFFIXES
 
 SYSTEM = platform.system()
 TEST_SCRIPT_DIR = Path(__file__).parent.parent / "data"
+# Allow overriding the duct executable for testing external builds (e.g., PyInstaller)
+_DUCT_EXECUTABLES = os.environ.get("DUCT_TEST_EXECUTABLES", "duct,con-duct run").split(
+    ","
+)
 
 
-def test_sanity(temp_output_dir: str) -> None:
-    command = f"duct -p {temp_output_dir}log_ sleep 0.1"
+@pytest.fixture(params=_DUCT_EXECUTABLES)
+def duct_cmd(request: pytest.FixtureRequest) -> str:
+    """Fixture that parametrizes tests to run with different duct entry points."""
+    return request.param
+
+
+def test_sanity(temp_output_dir: str, duct_cmd: str) -> None:
+    command = f"{duct_cmd} -p {temp_output_dir}log_ sleep 0.1"
     subprocess.check_output(command, shell=True)
 
 
 @pytest.mark.flaky(reruns=3)
 @pytest.mark.parametrize("mode", ["plain", "subshell", "nohup", "setsid"])
 @pytest.mark.parametrize("num_children", [1, 2, 10])
-def test_spawn_children(temp_output_dir: str, mode: str, num_children: int) -> None:
+def test_spawn_children(
+    temp_output_dir: str, duct_cmd: str, mode: str, num_children: int
+) -> None:
     duct_prefix = f"{temp_output_dir}log_"
     script_path = TEST_SCRIPT_DIR / "spawn_children.sh"
     dur = "0.3"
-    command = f"duct -q --s-i 0.001 --r-i 0.01 -p {duct_prefix} {script_path} {mode} {num_children} {dur}"
+    command = (
+        f"{duct_cmd} -q --s-i 0.001 --r-i 0.01 "
+        f"-p {duct_prefix} {script_path} {mode} {num_children} {dur}"
+    )
     subprocess.check_output(command, shell=True)
 
     with open(f"{duct_prefix}{SUFFIXES['usage']}") as usage_file:
@@ -44,10 +60,10 @@ def test_spawn_children(temp_output_dir: str, mode: str, num_children: int) -> N
 
 
 @pytest.mark.parametrize("session_mode", ["new-session", "current-session"])
-def test_session_modes(temp_output_dir: str, session_mode: str) -> None:
+def test_session_modes(temp_output_dir: str, duct_cmd: str, session_mode: str) -> None:
     """Test that both session modes work correctly and collect appropriate data."""
     duct_prefix = f"{temp_output_dir}log_"
-    command = f"duct -q --s-i 0.01 --r-i 0.05 --mode {session_mode} -p {duct_prefix} sleep 0.3"
+    command = f"{duct_cmd} -q --s-i 0.01 --r-i 0.05 --mode {session_mode} -p {duct_prefix} sleep 0.3"
     subprocess.check_output(command, shell=True)
 
     # Check that log files were created
@@ -79,7 +95,7 @@ def test_session_modes(temp_output_dir: str, session_mode: str) -> None:
     assert "sleep" in info_data["command"]
 
 
-def test_session_mode_behavior_difference(temp_output_dir: str) -> None:
+def test_session_mode_behavior_difference(temp_output_dir: str, duct_cmd: str) -> None:
     """Test that new-session and current-session modes behave differently."""
 
     # Start a unique background process in the current session
@@ -98,13 +114,13 @@ def test_session_mode_behavior_difference(temp_output_dir: str) -> None:
 
         # Run duct with new-session mode - should NOT see background process
         subprocess.check_output(
-            f"duct -q --s-i 0.01 --r-i 0.05 --mode new-session -p {new_session_prefix} sleep 2",
+            f"{duct_cmd} -q --s-i 0.01 --r-i 0.05 --mode new-session -p {new_session_prefix} sleep 2",
             shell=True,
         )
 
         # Run duct with current-session mode - should see background process
         subprocess.check_output(
-            f"duct -q --s-i 0.01 --r-i 0.05 --mode current-session -p {current_session_prefix} sleep 2",
+            f"{duct_cmd} -q --s-i 0.01 --r-i 0.05 --mode current-session -p {current_session_prefix} sleep 2",
             shell=True,
         )
 
@@ -153,13 +169,13 @@ def test_session_mode_behavior_difference(temp_output_dir: str) -> None:
                 background_process.wait()
 
 
-def test_logging_levels(temp_output_dir: str) -> None:
+def test_logging_levels(temp_output_dir: str, duct_cmd: str) -> None:
     """Test that --quiet and --log-level NONE suppress logging output."""
     duct_prefix = f"{temp_output_dir}log_"
 
     # Test normal logging - should see "Summary" in stderr
     result = subprocess.run(
-        f"con-duct run -p {duct_prefix} sleep 0.1",
+        f"{duct_cmd} -p {duct_prefix} sleep 0.1",
         shell=True,
         capture_output=True,
         text=True,
@@ -170,7 +186,7 @@ def test_logging_levels(temp_output_dir: str) -> None:
 
     # Test --quiet flag - should suppress logging
     result_quiet = subprocess.run(
-        f"con-duct run --quiet --clobber -p {duct_prefix} sleep 0.1",
+        f"{duct_cmd} --quiet --clobber -p {duct_prefix} sleep 0.1",
         shell=True,
         capture_output=True,
         text=True,
@@ -183,7 +199,7 @@ def test_logging_levels(temp_output_dir: str) -> None:
 
     # Test --log-level NONE - should suppress logging
     result_none = subprocess.run(
-        f"con-duct run --log-level NONE --clobber -p {duct_prefix} sleep 0.1",
+        f"{duct_cmd} --log-level NONE --clobber -p {duct_prefix} sleep 0.1",
         shell=True,
         capture_output=True,
         text=True,


### PR DESCRIPTION
## Summary
- Add `DUCT_TEST_EXECUTABLES` env var to configure which executable(s) the e2e tests use
- By default, tests run twice: once with `duct` and once with `con-duct run`
- External builds (e.g., PyInstaller) can override to test their executable

## Usage

Default (tests both entry points):
```bash
pytest test/duct_main/test_e2e.py -v
```

External executable:
```bash
DUCT_TEST_EXECUTABLES="./dist/con-duct run" pytest test/duct_main/test_e2e.py -v
```

## Test plan

<details>
<summary>Default test run (both entry points)</summary>

```
$ pytest test/duct_main/test_e2e.py::test_sanity -v
============================================= test session starts =============================================
platform linux -- Python 3.13.11, pytest-9.0.2, pluggy-1.6.0 -- /home/austin/.venvs/duct/bin/python
cachedir: .pytest_cache
rootdir: /home/austin/devel/duct
configfile: pyproject.toml (WARNING: ignoring pytest config in tox.ini!)
plugins: rerunfailures-16.1
collected 2 items                                                                                             

test/duct_main/test_e2e.py::test_sanity[duct] PASSED                                                    [ 50%]
test/duct_main/test_e2e.py::test_sanity[con-duct run] PASSED                                            [100%]

============================================== 2 passed in 0.93s ==============================================
```

</details>

<details>
<summary>PyInstaller executable test run</summary>

```
$ DUCT_TEST_EXECUTABLES="./linux-test-2 run" pytest test/duct_main/test_e2e.py::test_sanity -v
============================================= test session starts =============================================
platform linux -- Python 3.13.11, pytest-9.0.2, pluggy-1.6.0 -- /home/austin/.venvs/duct/bin/python
cachedir: .pytest_cache
rootdir: /home/austin/devel/duct
configfile: pyproject.toml (WARNING: ignoring pytest config in tox.ini!)
plugins: rerunfailures-16.1
collected 1 item                                                                                              

test/duct_main/test_e2e.py::test_sanity[./linux-test-2 run] PASSED                                      [100%]

============================================== 1 passed in 0.49s ==============================================
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)