### PR TITLE
refactor: extract models and enums to _models.py

### DIFF
--- a/src/con_duct/_models.py
+++ b/src/con_duct/_models.py
@@ -1,0 +1,275 @@
+"""Data models and enums for con-duct."""
+
+from __future__ import annotations
+from collections import Counter
+from collections.abc import Iterator
+from dataclasses import asdict, dataclass, field
+from datetime import datetime
+from enum import Enum
+import logging
+import os
+import re
+from typing import Any, Optional
+from con_duct._constants import SUFFIXES
+from con_duct._utils import assert_num
+
+lgr = logging.getLogger("con-duct")
+
+
+class Outputs(str, Enum):
+    ALL = "all"
+    NONE = "none"
+    STDOUT = "stdout"
+    STDERR = "stderr"
+
+    def __str__(self) -> str:
+        return self.value
+
+    def has_stdout(self) -> bool:
+        return self is Outputs.ALL or self is Outputs.STDOUT
+
+    def has_stderr(self) -> bool:
+        return self is Outputs.ALL or self is Outputs.STDERR
+
+
+class RecordTypes(str, Enum):
+    ALL = "all"
+    SYSTEM_SUMMARY = "system-summary"
+    PROCESSES_SAMPLES = "processes-samples"
+
+    def __str__(self) -> str:
+        return self.value
+
+    def has_system_summary(self) -> bool:
+        return self is RecordTypes.ALL or self is RecordTypes.SYSTEM_SUMMARY
+
+    def has_processes_samples(self) -> bool:
+        return self is RecordTypes.ALL or self is RecordTypes.PROCESSES_SAMPLES
+
+
+class SessionMode(str, Enum):
+    NEW_SESSION = "new-session"
+    CURRENT_SESSION = "current-session"
+
+    def __str__(self) -> str:
+        return self.value
+
+
+@dataclass
+class SystemInfo:
+    cpu_total: int
+    memory_total: int
+    hostname: str | None
+    uid: int
+    user: str | None
+
+
+@dataclass
+class ProcessStats:
+    pcpu: float  # %CPU
+    pmem: float  # %MEM
+    rss: int  # Memory Resident Set Size in Bytes
+    vsz: int  # Virtual Memory size in Bytes
+    timestamp: str
+    etime: str
+    stat: Counter
+    cmd: str
+
+    def aggregate(self, other: ProcessStats) -> ProcessStats:
+        cmd = self.cmd
+        if self.cmd != other.cmd:
+            lgr.debug(
+                f"cmd has changed. Previous measurement was {self.cmd}, now {other.cmd}."
+            )
+            # Brackets indicate that the kernel has substituted an abbreviation.
+            surrounded_by_brackets = r"^\[.+\]"
+            if re.search(surrounded_by_brackets, self.cmd):
+                lgr.debug(f"using {other.cmd}.")
+                cmd = other.cmd
+            lgr.debug(f"using {self.cmd}.")
+
+        new_counter: Counter = Counter()
+        new_counter.update(self.stat)
+        new_counter.update(other.stat)
+        return ProcessStats(
+            pcpu=max(self.pcpu, other.pcpu),
+            pmem=max(self.pmem, other.pmem),
+            rss=max(self.rss, other.rss),
+            vsz=max(self.vsz, other.vsz),
+            timestamp=max(self.timestamp, other.timestamp),
+            etime=other.etime,  # For the aggregate always take the latest
+            stat=new_counter,
+            cmd=cmd,
+        )
+
+    def for_json(self) -> dict:
+        ret = asdict(self)
+        ret["stat"] = dict(self.stat)
+        return ret
+
+    def __post_init__(self) -> None:
+        self._validate()
+
+    def _validate(self) -> None:
+        assert_num(self.pcpu, self.pmem, self.rss, self.vsz)
+
+
+@dataclass
+class LogPaths:
+    stdout: str
+    stderr: str
+    usage: str
+    info: str
+    prefix: str
+
+    def __iter__(self) -> Iterator[tuple[str, str]]:
+        for name, path in asdict(self).items():
+            if name != "prefix":
+                yield name, path
+
+    @classmethod
+    def create(cls, output_prefix: str, pid: None | int = None) -> LogPaths:
+        datetime_filesafe = datetime.now().strftime("%Y.%m.%dT%H.%M.%S")
+        formatted_prefix = output_prefix.format(
+            pid=pid, datetime_filesafe=datetime_filesafe
+        )
+        return cls(
+            stdout=f"{formatted_prefix}{SUFFIXES['stdout']}",
+            stderr=f"{formatted_prefix}{SUFFIXES['stderr']}",
+            usage=f"{formatted_prefix}{SUFFIXES['usage']}",
+            info=f"{formatted_prefix}{SUFFIXES['info']}",
+            prefix=formatted_prefix,
+        )
+
+    def prepare_paths(self, clobber: bool, capture_outputs: Outputs) -> None:
+        conflicts = [path for _name, path in self if os.path.exists(path)]
+        if conflicts and not clobber:
+            raise FileExistsError(
+                "Conflicting files:\n"
+                + "\n".join(f"- {path}" for path in conflicts)
+                + "\nUse --clobber to overwrite conflicting files."
+            )
+
+        if self.prefix.endswith(os.sep):  # If it ends in "/" (for linux) treat as a dir
+            os.makedirs(self.prefix, exist_ok=True)
+        else:
+            # Path does not end with a separator, treat the last part as a filename
+            directory = os.path.dirname(self.prefix)
+            if directory:
+                os.makedirs(directory, exist_ok=True)
+        for name, path in self:
+            if name == SUFFIXES["stdout"] and not capture_outputs.has_stdout():
+                continue
+            elif name == SUFFIXES["stderr"] and not capture_outputs.has_stderr():
+                continue
+            # TODO: AVOID PRECREATION -- would interfere e.g. with git-annex
+            # assistant monitoring new files to be created and committing
+            # as soon as they are closed
+            open(path, "w").close()
+
+
+@dataclass
+class Averages:
+    rss: Optional[float] = None
+    vsz: Optional[float] = None
+    pmem: Optional[float] = None
+    pcpu: Optional[float] = None
+    num_samples: int = 0
+
+    def update(self: Averages, other: Sample) -> None:
+        assert_num(other.total_rss, other.total_vsz, other.total_pmem, other.total_pcpu)
+        if not self.num_samples:
+            self.num_samples += 1
+            self.rss = other.total_rss
+            self.vsz = other.total_vsz
+            self.pmem = other.total_pmem
+            self.pcpu = other.total_pcpu
+        else:
+            assert self.rss is not None
+            assert self.vsz is not None
+            assert self.pmem is not None
+            assert self.pcpu is not None
+            assert other.total_rss is not None
+            assert other.total_vsz is not None
+            assert other.total_pmem is not None
+            assert other.total_pcpu is not None
+            self.num_samples += 1
+            self.rss += (other.total_rss - self.rss) / self.num_samples
+            self.vsz += (other.total_vsz - self.vsz) / self.num_samples
+            self.pmem += (other.total_pmem - self.pmem) / self.num_samples
+            self.pcpu += (other.total_pcpu - self.pcpu) / self.num_samples
+
+    @classmethod
+    def from_sample(cls, sample: Sample) -> Averages:
+        assert_num(
+            sample.total_rss, sample.total_vsz, sample.total_pmem, sample.total_pcpu
+        )
+        return cls(
+            rss=sample.total_rss,
+            vsz=sample.total_vsz,
+            pmem=sample.total_pmem,
+            pcpu=sample.total_pcpu,
+            num_samples=1,
+        )
+
+
+@dataclass
+class Sample:
+    stats: dict[int, ProcessStats] = field(default_factory=dict)
+    averages: Averages = field(default_factory=Averages)
+    total_rss: Optional[int] = None
+    total_vsz: Optional[int] = None
+    total_pmem: Optional[float] = None
+    total_pcpu: Optional[float] = None
+    timestamp: str = ""  # TS of last sample collected
+
+    def add_pid(self, pid: int, stats: ProcessStats) -> None:
+        # We do not calculate averages when we add a pid because we require all pids first
+        assert (
+            self.stats.get(pid) is None
+        )  # add_pid should only be called when pid not in Sample
+        self.total_rss = (self.total_rss or 0) + stats.rss
+        self.total_vsz = (self.total_vsz or 0) + stats.vsz
+        self.total_pmem = (self.total_pmem or 0.0) + stats.pmem
+        self.total_pcpu = (self.total_pcpu or 0.0) + stats.pcpu
+        self.stats[pid] = stats
+        self.timestamp = max(self.timestamp, stats.timestamp)
+
+    def aggregate(self: Sample, other: Sample) -> Sample:
+        output = Sample()
+        for pid in self.stats.keys() | other.stats.keys():
+            if (mine := self.stats.get(pid)) is not None:
+                if (theirs := other.stats.get(pid)) is not None:
+                    output.add_pid(pid, mine.aggregate(theirs))
+                else:
+                    output.add_pid(pid, mine)
+            else:
+                output.add_pid(pid, other.stats[pid])
+        assert other.total_pmem is not None
+        assert other.total_pcpu is not None
+        assert other.total_rss is not None
+        assert other.total_vsz is not None
+        output.total_pmem = max(self.total_pmem or 0.0, other.total_pmem)
+        output.total_pcpu = max(self.total_pcpu or 0.0, other.total_pcpu)
+        output.total_rss = max(self.total_rss or 0, other.total_rss)
+        output.total_vsz = max(self.total_vsz or 0, other.total_vsz)
+        output.averages = self.averages
+        output.averages.update(other)
+        return output
+
+    def for_json(self) -> dict[str, Any]:
+        d = {
+            "timestamp": self.timestamp,
+            "num_samples": self.averages.num_samples,
+            "processes": {
+                str(pid): stats.for_json() for pid, stats in self.stats.items()
+            },
+            "totals": {  # total of all processes during this sample
+                "pmem": self.total_pmem,
+                "pcpu": self.total_pcpu,
+                "rss": self.total_rss,
+                "vsz": self.total_vsz,
+            },
+            "averages": asdict(self.averages) if self.averages.num_samples >= 1 else {},
+        }
+        return d

--- a/src/con_duct/_utils.py
+++ b/src/con_duct/_utils.py
@@ -1,0 +1,8 @@
+"""Utility functions for con-duct."""
+
+from typing import Any
+
+
+def assert_num(*values: Any) -> None:
+    for value in values:
+        assert isinstance(value, (float, int))

--- a/src/con_duct/_utils.py
+++ b/src/con_duct/_utils.py
@@ -6,3 +6,14 @@ from typing import Any
 def assert_num(*values: Any) -> None:
     for value in values:
         assert isinstance(value, (float, int))
+
+
+def parse_version(version_str: str) -> tuple[int, int, int]:
+    x_y_z = version_str.split(".")
+    if len(x_y_z) != 3:
+        raise ValueError(
+            f"Invalid version format: {version_str}. Expected 'x.y.z' format."
+        )
+
+    x, y, z = map(int, x_y_z)  # Unpacking forces exactly 3 elements
+    return (x, y, z)

--- a/src/con_duct/cli.py
+++ b/src/con_duct/cli.py
@@ -7,13 +7,8 @@ import sys
 import textwrap
 from typing import List, Optional
 from con_duct import __version__
-from con_duct.duct_main import (
-    DUCT_OUTPUT_PREFIX,
-    EXECUTION_SUMMARY_FORMAT,
-    Outputs,
-    RecordTypes,
-    SessionMode,
-)
+from con_duct._models import Outputs, RecordTypes, SessionMode
+from con_duct.duct_main import DUCT_OUTPUT_PREFIX, EXECUTION_SUMMARY_FORMAT
 from con_duct.duct_main import execute as duct_execute
 from con_duct.ls import LS_FIELD_CHOICES, ls
 from con_duct.plot import matplotlib_plot

--- a/src/con_duct/duct_main.py
+++ b/src/con_duct/duct_main.py
@@ -1,17 +1,15 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 from collections import Counter, deque
-from collections.abc import Iterable, Iterator
-from dataclasses import asdict, dataclass, field
+from collections.abc import Iterable
+from dataclasses import asdict
 from datetime import datetime
-from enum import Enum
 from importlib.metadata import version
 import json
 import logging
 import math
 import os
 import platform
-import re
 import shutil
 import signal
 import socket
@@ -22,7 +20,17 @@ import threading
 import time
 from types import FrameType
 from typing import IO, Any, Callable, Optional, TextIO
-from con_duct._constants import ENV_PREFIXES, SUFFIXES
+from con_duct._constants import ENV_PREFIXES
+from con_duct._models import (
+    Averages,
+    LogPaths,
+    Outputs,
+    ProcessStats,
+    RecordTypes,
+    Sample,
+    SessionMode,
+    SystemInfo,
+)
 
 __version__ = version("con-duct")
 __schema_version__ = "0.2.2"
@@ -49,270 +57,6 @@ EXECUTION_SUMMARY_FORMAT = (
     "CPU Peak Usage: {peak_pcpu:.2f!N}%\n"
     "Average CPU Usage: {average_pcpu:.2f!N}%\n"
 )
-
-
-def assert_num(*values: Any) -> None:
-    for value in values:
-        assert isinstance(value, (float, int))
-
-
-class Outputs(str, Enum):
-    ALL = "all"
-    NONE = "none"
-    STDOUT = "stdout"
-    STDERR = "stderr"
-
-    def __str__(self) -> str:
-        return self.value
-
-    def has_stdout(self) -> bool:
-        return self is Outputs.ALL or self is Outputs.STDOUT
-
-    def has_stderr(self) -> bool:
-        return self is Outputs.ALL or self is Outputs.STDERR
-
-
-class RecordTypes(str, Enum):
-    ALL = "all"
-    SYSTEM_SUMMARY = "system-summary"
-    PROCESSES_SAMPLES = "processes-samples"
-
-    def __str__(self) -> str:
-        return self.value
-
-    def has_system_summary(self) -> bool:
-        return self is RecordTypes.ALL or self is RecordTypes.SYSTEM_SUMMARY
-
-    def has_processes_samples(self) -> bool:
-        return self is RecordTypes.ALL or self is RecordTypes.PROCESSES_SAMPLES
-
-
-class SessionMode(str, Enum):
-    NEW_SESSION = "new-session"
-    CURRENT_SESSION = "current-session"
-
-    def __str__(self) -> str:
-        return self.value
-
-
-@dataclass
-class SystemInfo:
-    cpu_total: int
-    memory_total: int
-    hostname: str | None
-    uid: int
-    user: str | None
-
-
-@dataclass
-class ProcessStats:
-    pcpu: float  # %CPU
-    pmem: float  # %MEM
-    rss: int  # Memory Resident Set Size in Bytes
-    vsz: int  # Virtual Memory size in Bytes
-    timestamp: str
-    etime: str
-    stat: Counter
-    cmd: str
-
-    def aggregate(self, other: ProcessStats) -> ProcessStats:
-        cmd = self.cmd
-        if self.cmd != other.cmd:
-            lgr.debug(
-                f"cmd has changed. Previous measurement was {self.cmd}, now {other.cmd}."
-            )
-            # Brackets indicate that the kernel has substituted an abbreviation.
-            surrounded_by_brackets = r"^\[.+\]"
-            if re.search(surrounded_by_brackets, self.cmd):
-                lgr.debug(f"using {other.cmd}.")
-                cmd = other.cmd
-            lgr.debug(f"using {self.cmd}.")
-
-        new_counter: Counter = Counter()
-        new_counter.update(self.stat)
-        new_counter.update(other.stat)
-        return ProcessStats(
-            pcpu=max(self.pcpu, other.pcpu),
-            pmem=max(self.pmem, other.pmem),
-            rss=max(self.rss, other.rss),
-            vsz=max(self.vsz, other.vsz),
-            timestamp=max(self.timestamp, other.timestamp),
-            etime=other.etime,  # For the aggregate always take the latest
-            stat=new_counter,
-            cmd=cmd,
-        )
-
-    def for_json(self) -> dict:
-        ret = asdict(self)
-        ret["stat"] = dict(self.stat)
-        return ret
-
-    def __post_init__(self) -> None:
-        self._validate()
-
-    def _validate(self) -> None:
-        assert_num(self.pcpu, self.pmem, self.rss, self.vsz)
-
-
-@dataclass
-class LogPaths:
-    stdout: str
-    stderr: str
-    usage: str
-    info: str
-    prefix: str
-
-    def __iter__(self) -> Iterator[tuple[str, str]]:
-        for name, path in asdict(self).items():
-            if name != "prefix":
-                yield name, path
-
-    @classmethod
-    def create(cls, output_prefix: str, pid: None | int = None) -> LogPaths:
-        datetime_filesafe = datetime.now().strftime("%Y.%m.%dT%H.%M.%S")
-        formatted_prefix = output_prefix.format(
-            pid=pid, datetime_filesafe=datetime_filesafe
-        )
-        return cls(
-            stdout=f"{formatted_prefix}{SUFFIXES['stdout']}",
-            stderr=f"{formatted_prefix}{SUFFIXES['stderr']}",
-            usage=f"{formatted_prefix}{SUFFIXES['usage']}",
-            info=f"{formatted_prefix}{SUFFIXES['info']}",
-            prefix=formatted_prefix,
-        )
-
-    def prepare_paths(self, clobber: bool, capture_outputs: Outputs) -> None:
-        conflicts = [path for _name, path in self if os.path.exists(path)]
-        if conflicts and not clobber:
-            raise FileExistsError(
-                "Conflicting files:\n"
-                + "\n".join(f"- {path}" for path in conflicts)
-                + "\nUse --clobber to overwrite conflicting files."
-            )
-
-        if self.prefix.endswith(os.sep):  # If it ends in "/" (for linux) treat as a dir
-            os.makedirs(self.prefix, exist_ok=True)
-        else:
-            # Path does not end with a separator, treat the last part as a filename
-            directory = os.path.dirname(self.prefix)
-            if directory:
-                os.makedirs(directory, exist_ok=True)
-        for name, path in self:
-            if name == SUFFIXES["stdout"] and not capture_outputs.has_stdout():
-                continue
-            elif name == SUFFIXES["stderr"] and not capture_outputs.has_stderr():
-                continue
-            # TODO: AVOID PRECREATION -- would interfere e.g. with git-annex
-            # assistant monitoring new files to be created and committing
-            # as soon as they are closed
-            open(path, "w").close()
-
-
-@dataclass
-class Averages:
-    rss: Optional[float] = None
-    vsz: Optional[float] = None
-    pmem: Optional[float] = None
-    pcpu: Optional[float] = None
-    num_samples: int = 0
-
-    def update(self: Averages, other: Sample) -> None:
-        assert_num(other.total_rss, other.total_vsz, other.total_pmem, other.total_pcpu)
-        if not self.num_samples:
-            self.num_samples += 1
-            self.rss = other.total_rss
-            self.vsz = other.total_vsz
-            self.pmem = other.total_pmem
-            self.pcpu = other.total_pcpu
-        else:
-            assert self.rss is not None
-            assert self.vsz is not None
-            assert self.pmem is not None
-            assert self.pcpu is not None
-            assert other.total_rss is not None
-            assert other.total_vsz is not None
-            assert other.total_pmem is not None
-            assert other.total_pcpu is not None
-            self.num_samples += 1
-            self.rss += (other.total_rss - self.rss) / self.num_samples
-            self.vsz += (other.total_vsz - self.vsz) / self.num_samples
-            self.pmem += (other.total_pmem - self.pmem) / self.num_samples
-            self.pcpu += (other.total_pcpu - self.pcpu) / self.num_samples
-
-    @classmethod
-    def from_sample(cls, sample: Sample) -> Averages:
-        assert_num(
-            sample.total_rss, sample.total_vsz, sample.total_pmem, sample.total_pcpu
-        )
-        return cls(
-            rss=sample.total_rss,
-            vsz=sample.total_vsz,
-            pmem=sample.total_pmem,
-            pcpu=sample.total_pcpu,
-            num_samples=1,
-        )
-
-
-@dataclass
-class Sample:
-    stats: dict[int, ProcessStats] = field(default_factory=dict)
-    averages: Averages = field(default_factory=Averages)
-    total_rss: Optional[int] = None
-    total_vsz: Optional[int] = None
-    total_pmem: Optional[float] = None
-    total_pcpu: Optional[float] = None
-    timestamp: str = ""  # TS of last sample collected
-
-    def add_pid(self, pid: int, stats: ProcessStats) -> None:
-        # We do not calculate averages when we add a pid because we require all pids first
-        assert (
-            self.stats.get(pid) is None
-        )  # add_pid should only be called when pid not in Sample
-        self.total_rss = (self.total_rss or 0) + stats.rss
-        self.total_vsz = (self.total_vsz or 0) + stats.vsz
-        self.total_pmem = (self.total_pmem or 0.0) + stats.pmem
-        self.total_pcpu = (self.total_pcpu or 0.0) + stats.pcpu
-        self.stats[pid] = stats
-        self.timestamp = max(self.timestamp, stats.timestamp)
-
-    def aggregate(self: Sample, other: Sample) -> Sample:
-        output = Sample()
-        for pid in self.stats.keys() | other.stats.keys():
-            if (mine := self.stats.get(pid)) is not None:
-                if (theirs := other.stats.get(pid)) is not None:
-                    output.add_pid(pid, mine.aggregate(theirs))
-                else:
-                    output.add_pid(pid, mine)
-            else:
-                output.add_pid(pid, other.stats[pid])
-        assert other.total_pmem is not None
-        assert other.total_pcpu is not None
-        assert other.total_rss is not None
-        assert other.total_vsz is not None
-        output.total_pmem = max(self.total_pmem or 0.0, other.total_pmem)
-        output.total_pcpu = max(self.total_pcpu or 0.0, other.total_pcpu)
-        output.total_rss = max(self.total_rss or 0, other.total_rss)
-        output.total_vsz = max(self.total_vsz or 0, other.total_vsz)
-        output.averages = self.averages
-        output.averages.update(other)
-        return output
-
-    def for_json(self) -> dict[str, Any]:
-        d = {
-            "timestamp": self.timestamp,
-            "num_samples": self.averages.num_samples,
-            "processes": {
-                str(pid): stats.for_json() for pid, stats in self.stats.items()
-            },
-            "totals": {  # total of all processes during this sample
-                "pmem": self.total_pmem,
-                "pcpu": self.total_pcpu,
-                "rss": self.total_rss,
-                "vsz": self.total_vsz,
-            },
-            "averages": asdict(self.averages) if self.averages.num_samples >= 1 else {},
-        }
-        return d
 
 
 def _get_sample_linux(session_id: int) -> Sample:

--- a/src/con_duct/ls.py
+++ b/src/con_duct/ls.py
@@ -6,9 +6,9 @@ import logging
 import re
 from types import ModuleType
 from typing import Any, Dict, List, Optional
+from con_duct._utils import parse_version
 from con_duct.duct_main import DUCT_OUTPUT_PREFIX, SummaryFormatter, __schema_version__
 from con_duct.json_utils import is_info_file
-from con_duct.utils import parse_version
 
 try:
     import pyout  # type: ignore

--- a/src/con_duct/utils.py
+++ b/src/con_duct/utils.py
@@ -1,9 +1,0 @@
-def parse_version(version_str: str) -> tuple[int, int, int]:
-    x_y_z = version_str.split(".")
-    if len(x_y_z) != 3:
-        raise ValueError(
-            f"Invalid version format: {version_str}. Expected 'x.y.z' format."
-        )
-
-    x, y, z = map(int, x_y_z)  # Unpacking forces exactly 3 elements
-    return (x, y, z)

--- a/test/duct_main/test_aggregation.py
+++ b/test/duct_main/test_aggregation.py
@@ -4,7 +4,8 @@ import os
 from typing import cast
 from unittest import mock
 import pytest
-from con_duct.duct_main import EXECUTION_SUMMARY_FORMAT, ProcessStats, Report, Sample
+from con_duct._models import ProcessStats, Sample
+from con_duct.duct_main import EXECUTION_SUMMARY_FORMAT, Report
 
 stat0 = ProcessStats(
     pcpu=0.0,

--- a/test/duct_main/test_duct_utils.py
+++ b/test/duct_main/test_duct_utils.py
@@ -1,7 +1,7 @@
 """Tests for utility functions in duct_main.py"""
 
 import pytest
-from con_duct.duct_main import assert_num
+from con_duct._utils import assert_num
 
 
 @pytest.mark.parametrize("input_value", [0, 1, 2, -1, 100, 0.001, -1.68])

--- a/test/duct_main/test_execution.py
+++ b/test/duct_main/test_execution.py
@@ -12,7 +12,7 @@ import pytest
 from utils import assert_files, run_duct_command
 from con_duct import duct_main
 from con_duct._constants import SUFFIXES
-from con_duct.duct_main import Outputs
+from con_duct._models import Outputs
 
 
 def test_sample_less_than_report_interval(temp_output_dir: str) -> None:

--- a/test/duct_main/test_log_paths.py
+++ b/test/duct_main/test_log_paths.py
@@ -4,7 +4,7 @@ import os
 import re
 from unittest.mock import MagicMock, call, patch
 import pytest
-from con_duct.duct_main import LogPaths, Outputs
+from con_duct._models import LogPaths, Outputs
 
 
 def test_log_paths_filesafe_datetime_prefix() -> None:

--- a/test/duct_main/test_prepare_outputs.py
+++ b/test/duct_main/test_prepare_outputs.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 import subprocess
 from unittest.mock import MagicMock, call, patch
 from utils import MockStream
-from con_duct.duct_main import LogPaths, Outputs, prepare_outputs
+from con_duct._models import LogPaths, Outputs
+from con_duct.duct_main import prepare_outputs
 
 
 @patch("builtins.open", new_callable=MagicMock)

--- a/test/duct_main/test_report.py
+++ b/test/duct_main/test_report.py
@@ -6,13 +6,8 @@ import os
 import subprocess
 from unittest import mock
 import pytest
-from con_duct.duct_main import (
-    EXECUTION_SUMMARY_FORMAT,
-    Averages,
-    ProcessStats,
-    Report,
-    Sample,
-)
+from con_duct._models import Averages, ProcessStats, Sample
+from con_duct.duct_main import EXECUTION_SUMMARY_FORMAT, Report
 
 stat0 = ProcessStats(
     pcpu=0.0,

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,5 +1,5 @@
 import pytest
-from con_duct.utils import parse_version
+from con_duct._utils import parse_version
 
 
 @pytest.mark.parametrize(

--- a/test/utils.py
+++ b/test/utils.py
@@ -14,13 +14,8 @@ def run_duct_command(cli_args: list[str], **kwargs: Any) -> int:
     Returns:
         Exit code from the executed command
     """
-    from con_duct.duct_main import (
-        DUCT_OUTPUT_PREFIX,
-        EXECUTION_SUMMARY_FORMAT,
-        Outputs,
-        RecordTypes,
-        SessionMode,
-    )
+    from con_duct._models import Outputs, RecordTypes, SessionMode
+    from con_duct.duct_main import DUCT_OUTPUT_PREFIX, EXECUTION_SUMMARY_FORMAT
     from con_duct.duct_main import execute as duct_execute
 
     command = cli_args[0]


### PR DESCRIPTION
## Summary

- Move enums (`Outputs`, `RecordTypes`, `SessionMode`) to `_models.py`
- Move dataclasses (`SystemInfo`, `ProcessStats`, `LogPaths`, `Averages`, `Sample`) to `_models.py`
- Consolidate `utils.py` and `_utils.py` into single `_utils.py` with `assert_num` and `parse_version`
- Update imports in `cli.py`, `duct_main.py`, `ls.py`, and test files

Part of #372

## Test plan

- [x] All tests pass (`tox -e py3`)
- [x] Type checking passes (`tox -e typing`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)