### PR TITLE
refactor: extract SigIntHandler to _signals.py

### DIFF
--- a/src/con_duct/_signals.py
+++ b/src/con_duct/_signals.py
@@ -1,0 +1,41 @@
+"""Signal handlers for con-duct."""
+
+from __future__ import annotations
+import logging
+import os
+import signal
+from types import FrameType
+from typing import Optional
+
+lgr = logging.getLogger("con-duct")
+
+
+class SigIntHandler:
+    """
+    Handler of SIGINT signals received by the process running duct.
+    """
+
+    def __init__(self, pid: int) -> None:
+        """
+        Parameters
+        ----------
+        pid : int
+            The PID of the process monitored by duct
+        """
+        self.pid: int = pid
+        self.sigcount: int = 0
+
+    def __call__(self, _sig: int, _frame: Optional[FrameType]) -> None:
+        self.sigcount += 1
+        if self.sigcount == 1:
+            lgr.info("Received SIGINT, passing to command")
+            os.kill(self.pid, signal.SIGINT)
+        elif self.sigcount == 2:
+            lgr.info("Received second SIGINT, again passing to command")
+            os.kill(self.pid, signal.SIGINT)
+        elif self.sigcount == 3:
+            lgr.warning("Received third SIGINT, forcefully killing command process")
+            os.kill(self.pid, signal.SIGKILL)
+        elif self.sigcount >= 4:
+            lgr.critical("Exiting duct, skipping cleanup")
+            os._exit(1)


### PR DESCRIPTION
## Summary
- Extract `SigIntHandler` class from `duct_main.py` to new `_signals.py` module
- Remove unused `FrameType` import from `duct_main.py`

Part of #372

## Test plan
- [x] All 346 tests pass
- [x] Lint passes
- [x] Typing passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)