### PR TITLE
refactor: extract sampling functions to _sampling.py

### DIFF
--- a/src/con_duct/_sampling.py
+++ b/src/con_duct/_sampling.py
@@ -1,0 +1,135 @@
+"""Platform-specific process sampling for con-duct."""
+
+from __future__ import annotations
+from collections import Counter, deque
+from datetime import datetime
+import logging
+import os
+import platform
+import subprocess
+from typing import Callable, Optional
+from con_duct._models import Averages, ProcessStats, Sample
+
+SYSTEM = platform.system()
+
+lgr = logging.getLogger("con-duct")
+
+
+def _get_sample_linux(session_id: int) -> Sample:
+    sample = Sample()
+
+    ps_command = [
+        "ps",
+        "-w",
+        "-s",
+        str(session_id),
+        "-o",
+        "pid,pcpu,pmem,rss,vsz,etime,stat,cmd",
+    ]
+    output = subprocess.check_output(ps_command, text=True)
+
+    for line in output.splitlines()[1:]:
+        if not line:
+            continue
+
+        pid, pcpu, pmem, rss_kib, vsz_kib, etime, stat, cmd = line.split(maxsplit=7)
+
+        sample.add_pid(
+            pid=int(pid),
+            stats=ProcessStats(
+                pcpu=float(pcpu),
+                pmem=float(pmem),
+                rss=int(rss_kib) * 1024,
+                vsz=int(vsz_kib) * 1024,
+                timestamp=datetime.now().astimezone().isoformat(),
+                etime=etime,
+                stat=Counter([stat]),
+                cmd=cmd,
+            ),
+        )
+    sample.averages = Averages.from_sample(sample=sample)
+    return sample
+
+
+def _try_to_get_sid(pid: int) -> int:
+    """
+    It is possible that the `pid` returned by the top `ps` call no longer exists at time of `getsid` request.
+    """
+    try:
+        return os.getsid(pid)
+    except ProcessLookupError as exc:
+        lgr.debug(f"Error fetching session ID for PID {pid}: {str(exc)}")
+        return -1
+
+
+def _get_ps_lines_mac() -> list[str]:
+    ps_command = [
+        "ps",
+        "-ax",
+        "-o",
+        "pid,pcpu,pmem,rss,vsz,etime,stat,args",
+    ]
+    output = subprocess.check_output(ps_command, text=True)
+
+    lines = [line for line in output.splitlines()[1:] if line]
+    return lines
+
+
+def _add_pid_to_sample_from_line_mac(
+    line: str, pid_to_matching_sid: dict[int, int], sample: Sample
+) -> None:
+    pid, pcpu, pmem, rss_kb, vsz_kb, etime, stat, cmd = line.split(maxsplit=7)
+
+    if pid_to_matching_sid.get(int(pid)) is not None:
+        sample.add_pid(
+            pid=int(pid),
+            stats=ProcessStats(
+                pcpu=float(pcpu),
+                pmem=float(pmem),
+                rss=int(rss_kb) * 1024,
+                vsz=int(vsz_kb) * 1024,
+                timestamp=datetime.now().astimezone().isoformat(),
+                etime=etime,
+                stat=Counter([stat]),
+                cmd=cmd,
+            ),
+        )
+
+
+def _get_sample_mac(session_id: int) -> Optional[Sample]:
+    sample = Sample()
+
+    lines = _get_ps_lines_mac()
+    pid_to_matching_sid = {
+        pid: sid
+        for line in lines
+        if (sid := _try_to_get_sid(pid=(pid := int(line.split(maxsplit=1)[0]))))
+        == session_id
+    }
+
+    if not pid_to_matching_sid:
+        lgr.debug(f"No processes found for session ID {session_id}.")
+        return None
+
+    # collections.dequeue with maxlen=0 is used to approximate the
+    # performance of list comprehension (superior to basic for-loop)
+    # and also does not store `None` (or other) return values
+    deque(
+        (
+            _add_pid_to_sample_from_line_mac(  # type: ignore[func-returns-value]
+                line=line, pid_to_matching_sid=pid_to_matching_sid, sample=sample
+            )
+            for line in lines
+        ),
+        maxlen=0,
+    )
+
+    sample.averages = Averages.from_sample(sample=sample)
+    return sample
+
+
+_get_sample_per_system = {
+    "Linux": _get_sample_linux,
+    "Darwin": _get_sample_mac,
+}
+_get_sample: Callable[[int], Optional[Sample]] = _get_sample_per_system[SYSTEM]  # type: ignore[assignment]

--- a/src/con_duct/duct_main.py
+++ b/src/con_duct/duct_main.py
@@ -1,15 +1,12 @@
 #!/usr/bin/env python3
 from __future__ import annotations
-from collections import Counter, deque
 from collections.abc import Iterable
 from dataclasses import asdict
-from datetime import datetime
 from importlib.metadata import version
 import json
 import logging
 import math
 import os
-import platform
 import shutil
 import signal
 import socket
@@ -17,25 +14,22 @@ import subprocess
 import sys
 import threading
 import time
-from typing import IO, Any, Callable, Optional, TextIO
+from typing import IO, Any, Optional, TextIO
 from con_duct._constants import ENV_PREFIXES
 from con_duct._formatter import SummaryFormatter
 from con_duct._models import (
-    Averages,
     LogPaths,
     Outputs,
-    ProcessStats,
     RecordTypes,
     Sample,
     SessionMode,
     SystemInfo,
 )
+from con_duct._sampling import _get_sample
 from con_duct._signals import SigIntHandler
 
 __version__ = version("con-duct")
 __schema_version__ = "0.2.2"
-
-SYSTEM = platform.system()
 
 lgr = logging.getLogger("con-duct")
 
@@ -57,126 +51,6 @@ EXECUTION_SUMMARY_FORMAT = (
     "CPU Peak Usage: {peak_pcpu:.2f!N}%\n"
     "Average CPU Usage: {average_pcpu:.2f!N}%\n"
 )
-
-
-def _get_sample_linux(session_id: int) -> Sample:
-    sample = Sample()
-
-    ps_command = [
-        "ps",
-        "-w",
-        "-s",
-        str(session_id),
-        "-o",
-        "pid,pcpu,pmem,rss,vsz,etime,stat,cmd",
-    ]
-    output = subprocess.check_output(ps_command, text=True)
-
-    for line in output.splitlines()[1:]:
-        if not line:
-            continue
-
-        pid, pcpu, pmem, rss_kib, vsz_kib, etime, stat, cmd = line.split(maxsplit=7)
-
-        sample.add_pid(
-            pid=int(pid),
-            stats=ProcessStats(
-                pcpu=float(pcpu),
-                pmem=float(pmem),
-                rss=int(rss_kib) * 1024,
-                vsz=int(vsz_kib) * 1024,
-                timestamp=datetime.now().astimezone().isoformat(),
-                etime=etime,
-                stat=Counter([stat]),
-                cmd=cmd,
-            ),
-        )
-    sample.averages = Averages.from_sample(sample=sample)
-    return sample
-
-
-def _try_to_get_sid(pid: int) -> int:
-    """
-    It is possible that the `pid` returned by the top `ps` call no longer exists at time of `getsid` request.
-    """
-    try:
-        return os.getsid(pid)
-    except ProcessLookupError as exc:
-        lgr.debug(f"Error fetching session ID for PID {pid}: {str(exc)}")
-        return -1
-
-
-def _get_ps_lines_mac() -> list[str]:
-    ps_command = [
-        "ps",
-        "-ax",
-        "-o",
-        "pid,pcpu,pmem,rss,vsz,etime,stat,args",
-    ]
-    output = subprocess.check_output(ps_command, text=True)
-
-    lines = [line for line in output.splitlines()[1:] if line]
-    return lines
-
-
-def _add_pid_to_sample_from_line_mac(
-    line: str, pid_to_matching_sid: dict[int, int], sample: Sample
-) -> None:
-    pid, pcpu, pmem, rss_kb, vsz_kb, etime, stat, cmd = line.split(maxsplit=7)
-
-    if pid_to_matching_sid.get(int(pid)) is not None:
-        sample.add_pid(
-            pid=int(pid),
-            stats=ProcessStats(
-                pcpu=float(pcpu),
-                pmem=float(pmem),
-                rss=int(rss_kb) * 1024,
-                vsz=int(vsz_kb) * 1024,
-                timestamp=datetime.now().astimezone().isoformat(),
-                etime=etime,
-                stat=Counter([stat]),
-                cmd=cmd,
-            ),
-        )
-
-
-def _get_sample_mac(session_id: int) -> Optional[Sample]:
-    sample = Sample()
-
-    lines = _get_ps_lines_mac()
-    pid_to_matching_sid = {
-        pid: sid
-        for line in lines
-        if (sid := _try_to_get_sid(pid=(pid := int(line.split(maxsplit=1)[0]))))
-        == session_id
-    }
-
-    if not pid_to_matching_sid:
-        lgr.debug(f"No processes found for session ID {session_id}.")
-        return None
-
-    # collections.dequeue with maxlen=0 is used to approximate the
-    # performance of list comprehension (superior to basic for-loop)
-    # and also does not store `None` (or other) return values
-    deque(
-        (
-            _add_pid_to_sample_from_line_mac(  # type: ignore[func-returns-value]
-                line=line, pid_to_matching_sid=pid_to_matching_sid, sample=sample
-            )
-            for line in lines
-        ),
-        maxlen=0,
-    )
-
-    sample.averages = Averages.from_sample(sample=sample)
-    return sample
-
-
-_get_sample_per_system = {
-    "Linux": _get_sample_linux,
-    "Darwin": _get_sample_mac,
-}
-_get_sample: Callable[[int], Optional[Sample]] = _get_sample_per_system[SYSTEM]  # type: ignore[assignment]
 
 
 class Report:


### PR DESCRIPTION
## Summary
- Extract platform-specific sampling functions to new `_sampling.py` module:
  - `_get_sample_linux`
  - `_get_sample_mac` and helpers
  - `_get_sample` dispatcher
- Remove unused imports from `duct_main.py` (Counter, deque, datetime, platform, Callable, Averages, ProcessStats)

Part of #372

## Test plan
- [x] All 346 tests pass
- [x] Lint passes
- [x] Typing passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)