### PR TITLE
refactor: extract IO utilities to _output.py

### DIFF
--- a/src/con_duct/_output.py
+++ b/src/con_duct/_output.py
@@ -1,0 +1,110 @@
+"""I/O utilities for con-duct."""
+
+from __future__ import annotations
+from collections.abc import Iterable
+import os
+import subprocess
+import sys
+import threading
+import time
+from typing import IO, Any, TextIO
+from con_duct._models import LogPaths, Outputs
+
+
+class TailPipe:
+    """TailPipe simultaneously streams to an output stream (stdout or stderr) and a specified file."""
+
+    TAIL_CYCLE_TIME = 0.01
+
+    def __init__(self, file_path: str, buffer: IO[bytes]) -> None:
+        self.file_path = file_path
+        self.buffer = buffer
+        self.stop_event: threading.Event | None = None
+        self.infile: IO[bytes] | None = None
+        self.thread: threading.Thread | None = None
+
+    def start(self) -> None:
+        self.stop_event = threading.Event()
+        self.infile = open(self.file_path, "rb")
+        self.thread = threading.Thread(target=self._tail, daemon=True)
+        self.thread.start()
+
+    def fileno(self) -> int:
+        assert self.infile is not None
+        return self.infile.fileno()
+
+    def _catch_up(self) -> None:
+        assert self.infile is not None
+        data = self.infile.read()
+        if data:
+            self.buffer.write(data)
+            self.buffer.flush()
+
+    def _tail(self) -> None:
+        assert self.stop_event is not None
+        try:
+            while not self.stop_event.is_set():
+                self._catch_up()
+                time.sleep(TailPipe.TAIL_CYCLE_TIME)
+            # After stop event, collect and passthrough data one last time
+            self._catch_up()
+        except Exception:
+            raise
+        finally:
+            self.buffer.flush()
+
+    def close(self) -> None:
+        assert self.stop_event is not None
+        assert self.thread is not None
+        assert self.infile is not None
+        self.stop_event.set()
+        self.thread.join()
+        self.infile.close()
+
+
+def prepare_outputs(
+    capture_outputs: Outputs,
+    outputs: Outputs,
+    log_paths: LogPaths,
+) -> tuple[TextIO | TailPipe | int | None, TextIO | TailPipe | int | None]:
+    stdout: TextIO | TailPipe | int | None
+    stderr: TextIO | TailPipe | int | None
+
+    if capture_outputs.has_stdout():
+        if outputs.has_stdout():
+            stdout = TailPipe(log_paths.stdout, buffer=sys.stdout.buffer)
+            stdout.start()
+        else:
+            stdout = open(log_paths.stdout, "w")
+    elif outputs.has_stdout():
+        stdout = None
+    else:
+        stdout = subprocess.DEVNULL
+
+    if capture_outputs.has_stderr():
+        if outputs.has_stderr():
+            stderr = TailPipe(log_paths.stderr, buffer=sys.stderr.buffer)
+            stderr.start()
+        else:
+            stderr = open(log_paths.stderr, "w")
+    elif outputs.has_stderr():
+        stderr = None
+    else:
+        stderr = subprocess.DEVNULL
+    return stdout, stderr
+
+
+def safe_close_files(file_list: Iterable[Any]) -> None:
+    for f in file_list:
+        try:
+            f.close()
+        except Exception:
+            pass
+
+
+def remove_files(log_paths: LogPaths, assert_empty: bool = False) -> None:
+    for _, file_path in log_paths:
+        if os.path.exists(file_path):
+            if assert_empty:
+                assert os.stat(file_path).st_size == 0
+            os.remove(file_path)

--- a/src/con_duct/duct_main.py
+++ b/src/con_duct/duct_main.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 from __future__ import annotations
-from collections.abc import Iterable
 from dataclasses import asdict
 from importlib.metadata import version
 import json
@@ -11,7 +10,6 @@ import shutil
 import signal
 import socket
 import subprocess
-import sys
 import threading
 import time
 from typing import IO, Any, Optional, TextIO
@@ -25,6 +23,7 @@ from con_duct._models import (
     SessionMode,
     SystemInfo,
 )
+from con_duct._output import TailPipe, prepare_outputs, remove_files, safe_close_files
 from con_duct._sampling import _get_sample
 from con_duct._signals import SigIntHandler
 
@@ -280,105 +279,6 @@ def monitor_process(
         if stop_event.wait(timeout=sample_interval):
             lgr.debug("Breaking out because stop event was set")
             break
-
-
-class TailPipe:
-    """TailPipe simultaneously streams to an output stream (stdout or stderr) and a specified file."""
-
-    TAIL_CYCLE_TIME = 0.01
-
-    def __init__(self, file_path: str, buffer: IO[bytes]) -> None:
-        self.file_path = file_path
-        self.buffer = buffer
-        self.stop_event: threading.Event | None = None
-        self.infile: IO[bytes] | None = None
-        self.thread: threading.Thread | None = None
-
-    def start(self) -> None:
-        self.stop_event = threading.Event()
-        self.infile = open(self.file_path, "rb")
-        self.thread = threading.Thread(target=self._tail, daemon=True)
-        self.thread.start()
-
-    def fileno(self) -> int:
-        assert self.infile is not None
-        return self.infile.fileno()
-
-    def _catch_up(self) -> None:
-        assert self.infile is not None
-        data = self.infile.read()
-        if data:
-            self.buffer.write(data)
-            self.buffer.flush()
-
-    def _tail(self) -> None:
-        assert self.stop_event is not None
-        try:
-            while not self.stop_event.is_set():
-                self._catch_up()
-                time.sleep(TailPipe.TAIL_CYCLE_TIME)
-            # After stop event, collect and passthrough data one last time
-            self._catch_up()
-        except Exception:
-            raise
-        finally:
-            self.buffer.flush()
-
-    def close(self) -> None:
-        assert self.stop_event is not None
-        assert self.thread is not None
-        assert self.infile is not None
-        self.stop_event.set()
-        self.thread.join()
-        self.infile.close()
-
-
-def prepare_outputs(
-    capture_outputs: Outputs,
-    outputs: Outputs,
-    log_paths: LogPaths,
-) -> tuple[TextIO | TailPipe | int | None, TextIO | TailPipe | int | None]:
-    stdout: TextIO | TailPipe | int | None
-    stderr: TextIO | TailPipe | int | None
-
-    if capture_outputs.has_stdout():
-        if outputs.has_stdout():
-            stdout = TailPipe(log_paths.stdout, buffer=sys.stdout.buffer)
-            stdout.start()
-        else:
-            stdout = open(log_paths.stdout, "w")
-    elif outputs.has_stdout():
-        stdout = None
-    else:
-        stdout = subprocess.DEVNULL
-
-    if capture_outputs.has_stderr():
-        if outputs.has_stderr():
-            stderr = TailPipe(log_paths.stderr, buffer=sys.stderr.buffer)
-            stderr.start()
-        else:
-            stderr = open(log_paths.stderr, "w")
-    elif outputs.has_stderr():
-        stderr = None
-    else:
-        stderr = subprocess.DEVNULL
-    return stdout, stderr
-
-
-def safe_close_files(file_list: Iterable[Any]) -> None:
-    for f in file_list:
-        try:
-            f.close()
-        except Exception:
-            pass
-
-
-def remove_files(log_paths: LogPaths, assert_empty: bool = False) -> None:
-    for _, file_path in log_paths:
-        if os.path.exists(file_path):
-            if assert_empty:
-                assert os.stat(file_path).st_size == 0
-            os.remove(file_path)
 
 
 def execute(

--- a/test/duct_main/test_prepare_outputs.py
+++ b/test/duct_main/test_prepare_outputs.py
@@ -3,14 +3,14 @@ import subprocess
 from unittest.mock import MagicMock, call, patch
 from utils import MockStream
 from con_duct._models import LogPaths, Outputs
-from con_duct.duct_main import prepare_outputs
+from con_duct._output import prepare_outputs
 
 
 @patch("builtins.open", new_callable=MagicMock)
-@patch("con_duct.duct_main.TailPipe")
-@patch("con_duct.duct_main.LogPaths")
-@patch("con_duct.duct_main.sys.stderr", new_callable=MockStream)
-@patch("con_duct.duct_main.sys.stdout", new_callable=MockStream)
+@patch("con_duct._output.TailPipe")
+@patch("con_duct._output.LogPaths")
+@patch("con_duct._output.sys.stderr", new_callable=MockStream)
+@patch("con_duct._output.sys.stdout", new_callable=MockStream)
 def test_prepare_outputs_capture_none_output_none(
     _mock_stdout: MockStream,
     _mock_stderr: MockStream,
@@ -28,10 +28,10 @@ def test_prepare_outputs_capture_none_output_none(
 
 
 @patch("builtins.open", new_callable=MagicMock)
-@patch("con_duct.duct_main.TailPipe")
-@patch("con_duct.duct_main.LogPaths")
-@patch("con_duct.duct_main.sys.stderr", new_callable=MockStream)
-@patch("con_duct.duct_main.sys.stdout", new_callable=MockStream)
+@patch("con_duct._output.TailPipe")
+@patch("con_duct._output.LogPaths")
+@patch("con_duct._output.sys.stderr", new_callable=MockStream)
+@patch("con_duct._output.sys.stdout", new_callable=MockStream)
 def test_prepare_outputs_capture_none_output_stdout(
     _mock_stdout: MockStream,
     _mock_stderr: MockStream,
@@ -49,10 +49,10 @@ def test_prepare_outputs_capture_none_output_stdout(
 
 
 @patch("builtins.open", new_callable=MagicMock)
-@patch("con_duct.duct_main.TailPipe")
-@patch("con_duct.duct_main.LogPaths")
-@patch("con_duct.duct_main.sys.stderr", new_callable=MockStream)
-@patch("con_duct.duct_main.sys.stdout", new_callable=MockStream)
+@patch("con_duct._output.TailPipe")
+@patch("con_duct._output.LogPaths")
+@patch("con_duct._output.sys.stderr", new_callable=MockStream)
+@patch("con_duct._output.sys.stdout", new_callable=MockStream)
 def test_prepare_outputs_capture_none_output_stderr(
     _mock_stdout: MockStream,
     _mock_stderr: MockStream,
@@ -70,10 +70,10 @@ def test_prepare_outputs_capture_none_output_stderr(
 
 
 @patch("builtins.open", new_callable=MagicMock)
-@patch("con_duct.duct_main.TailPipe")
-@patch("con_duct.duct_main.LogPaths")
-@patch("con_duct.duct_main.sys.stderr", new_callable=MockStream)
-@patch("con_duct.duct_main.sys.stdout", new_callable=MockStream)
+@patch("con_duct._output.TailPipe")
+@patch("con_duct._output.LogPaths")
+@patch("con_duct._output.sys.stderr", new_callable=MockStream)
+@patch("con_duct._output.sys.stdout", new_callable=MockStream)
 def test_prepare_outputs_capture_none_output_all(
     _mock_stdout: MockStream,
     _mock_stderr: MockStream,
@@ -91,10 +91,10 @@ def test_prepare_outputs_capture_none_output_all(
 
 
 @patch("builtins.open", new_callable=MagicMock)
-@patch("con_duct.duct_main.TailPipe")
-@patch("con_duct.duct_main.LogPaths")
-@patch("con_duct.duct_main.sys.stderr", new_callable=MockStream)
-@patch("con_duct.duct_main.sys.stdout", new_callable=MockStream)
+@patch("con_duct._output.TailPipe")
+@patch("con_duct._output.LogPaths")
+@patch("con_duct._output.sys.stderr", new_callable=MockStream)
+@patch("con_duct._output.sys.stdout", new_callable=MockStream)
 def test_prepare_outputs_capture_stdout_output_none(
     _mock_stdout: MockStream,
     _mock_stderr: MockStream,
@@ -112,10 +112,10 @@ def test_prepare_outputs_capture_stdout_output_none(
 
 
 @patch("builtins.open", new_callable=MagicMock)
-@patch("con_duct.duct_main.TailPipe")
-@patch("con_duct.duct_main.LogPaths")
-@patch("con_duct.duct_main.sys.stderr", new_callable=MockStream)
-@patch("con_duct.duct_main.sys.stdout", new_callable=MockStream)
+@patch("con_duct._output.TailPipe")
+@patch("con_duct._output.LogPaths")
+@patch("con_duct._output.sys.stderr", new_callable=MockStream)
+@patch("con_duct._output.sys.stdout", new_callable=MockStream)
 def test_prepare_outputs_capture_stdout_output_stdout(
     mock_stdout: MockStream,
     _mock_stderr: MockStream,
@@ -135,10 +135,10 @@ def test_prepare_outputs_capture_stdout_output_stdout(
 
 
 @patch("builtins.open", new_callable=MagicMock)
-@patch("con_duct.duct_main.TailPipe")
-@patch("con_duct.duct_main.LogPaths")
-@patch("con_duct.duct_main.sys.stderr", new_callable=MockStream)
-@patch("con_duct.duct_main.sys.stdout", new_callable=MockStream)
+@patch("con_duct._output.TailPipe")
+@patch("con_duct._output.LogPaths")
+@patch("con_duct._output.sys.stderr", new_callable=MockStream)
+@patch("con_duct._output.sys.stdout", new_callable=MockStream)
 def test_prepare_outputs_capture_stdout_output_stderr(
     _mock_stdout: MockStream,
     _mock_stderr: MockStream,
@@ -156,10 +156,10 @@ def test_prepare_outputs_capture_stdout_output_stderr(
 
 
 @patch("builtins.open", new_callable=MagicMock)
-@patch("con_duct.duct_main.TailPipe")
-@patch("con_duct.duct_main.LogPaths")
-@patch("con_duct.duct_main.sys.stderr", new_callable=MockStream)
-@patch("con_duct.duct_main.sys.stdout", new_callable=MockStream)
+@patch("con_duct._output.TailPipe")
+@patch("con_duct._output.LogPaths")
+@patch("con_duct._output.sys.stderr", new_callable=MockStream)
+@patch("con_duct._output.sys.stdout", new_callable=MockStream)
 def test_prepare_outputs_capture_stdout_output_all(
     mock_stdout: MockStream,
     _mock_stderr: MockStream,
@@ -179,10 +179,10 @@ def test_prepare_outputs_capture_stdout_output_all(
 
 
 @patch("builtins.open", new_callable=MagicMock)
-@patch("con_duct.duct_main.TailPipe")
-@patch("con_duct.duct_main.LogPaths")
-@patch("con_duct.duct_main.sys.stderr", new_callable=MockStream)
-@patch("con_duct.duct_main.sys.stdout", new_callable=MockStream)
+@patch("con_duct._output.TailPipe")
+@patch("con_duct._output.LogPaths")
+@patch("con_duct._output.sys.stderr", new_callable=MockStream)
+@patch("con_duct._output.sys.stdout", new_callable=MockStream)
 def test_prepare_outputs_capture_stderr_output_none(
     _mock_stdout: MockStream,
     _mock_stderr: MockStream,
@@ -200,10 +200,10 @@ def test_prepare_outputs_capture_stderr_output_none(
 
 
 @patch("builtins.open", new_callable=MagicMock)
-@patch("con_duct.duct_main.TailPipe")
-@patch("con_duct.duct_main.LogPaths")
-@patch("con_duct.duct_main.sys.stderr", new_callable=MockStream)
-@patch("con_duct.duct_main.sys.stdout", new_callable=MockStream)
+@patch("con_duct._output.TailPipe")
+@patch("con_duct._output.LogPaths")
+@patch("con_duct._output.sys.stderr", new_callable=MockStream)
+@patch("con_duct._output.sys.stdout", new_callable=MockStream)
 def test_prepare_outputs_capture_stderr_output_stdout(
     _mock_stdout: MockStream,
     _mock_stderr: MockStream,
@@ -221,10 +221,10 @@ def test_prepare_outputs_capture_stderr_output_stdout(
 
 
 @patch("builtins.open", new_callable=MagicMock)
-@patch("con_duct.duct_main.TailPipe")
-@patch("con_duct.duct_main.LogPaths")
-@patch("con_duct.duct_main.sys.stderr", new_callable=MockStream)
-@patch("con_duct.duct_main.sys.stdout", new_callable=MockStream)
+@patch("con_duct._output.TailPipe")
+@patch("con_duct._output.LogPaths")
+@patch("con_duct._output.sys.stderr", new_callable=MockStream)
+@patch("con_duct._output.sys.stdout", new_callable=MockStream)
 def test_prepare_outputs_capture_stderr_output_stderr(
     _mock_stdout: MockStream,
     mock_stderr: MockStream,
@@ -244,10 +244,10 @@ def test_prepare_outputs_capture_stderr_output_stderr(
 
 
 @patch("builtins.open", new_callable=MagicMock)
-@patch("con_duct.duct_main.TailPipe")
-@patch("con_duct.duct_main.LogPaths")
-@patch("con_duct.duct_main.sys.stderr", new_callable=MockStream)
-@patch("con_duct.duct_main.sys.stdout", new_callable=MockStream)
+@patch("con_duct._output.TailPipe")
+@patch("con_duct._output.LogPaths")
+@patch("con_duct._output.sys.stderr", new_callable=MockStream)
+@patch("con_duct._output.sys.stdout", new_callable=MockStream)
 def test_prepare_outputs_capture_stderr_output_all(
     _mock_stdout: MockStream,
     mock_stderr: MockStream,
@@ -267,10 +267,10 @@ def test_prepare_outputs_capture_stderr_output_all(
 
 
 @patch("builtins.open", new_callable=MagicMock)
-@patch("con_duct.duct_main.TailPipe")
-@patch("con_duct.duct_main.LogPaths")
-@patch("con_duct.duct_main.sys.stderr", new_callable=MockStream)
-@patch("con_duct.duct_main.sys.stdout", new_callable=MockStream)
+@patch("con_duct._output.TailPipe")
+@patch("con_duct._output.LogPaths")
+@patch("con_duct._output.sys.stderr", new_callable=MockStream)
+@patch("con_duct._output.sys.stdout", new_callable=MockStream)
 def test_prepare_outputs_capture_all_output_none(
     _mock_stdout: MockStream,
     _mock_stderr: MockStream,
@@ -290,10 +290,10 @@ def test_prepare_outputs_capture_all_output_none(
 
 
 @patch("builtins.open", new_callable=MagicMock)
-@patch("con_duct.duct_main.TailPipe")
-@patch("con_duct.duct_main.LogPaths")
-@patch("con_duct.duct_main.sys.stderr", new_callable=MockStream)
-@patch("con_duct.duct_main.sys.stdout", new_callable=MockStream)
+@patch("con_duct._output.TailPipe")
+@patch("con_duct._output.LogPaths")
+@patch("con_duct._output.sys.stderr", new_callable=MockStream)
+@patch("con_duct._output.sys.stdout", new_callable=MockStream)
 def test_prepare_outputs_capture_all_output_stdout(
     mock_stdout: MockStream,
     _mock_stderr: MockStream,
@@ -311,10 +311,10 @@ def test_prepare_outputs_capture_all_output_stdout(
 
 
 @patch("builtins.open", new_callable=MagicMock)
-@patch("con_duct.duct_main.TailPipe")
-@patch("con_duct.duct_main.LogPaths")
-@patch("con_duct.duct_main.sys.stderr", new_callable=MockStream)
-@patch("con_duct.duct_main.sys.stdout", new_callable=MockStream)
+@patch("con_duct._output.TailPipe")
+@patch("con_duct._output.LogPaths")
+@patch("con_duct._output.sys.stderr", new_callable=MockStream)
+@patch("con_duct._output.sys.stdout", new_callable=MockStream)
 def test_prepare_outputs_capture_all_output_stderr(
     _mock_stdout: MockStream,
     mock_stderr: MockStream,
@@ -334,10 +334,10 @@ def test_prepare_outputs_capture_all_output_stderr(
 
 
 @patch("builtins.open", new_callable=MagicMock)
-@patch("con_duct.duct_main.TailPipe")
-@patch("con_duct.duct_main.LogPaths")
-@patch("con_duct.duct_main.sys.stderr", new_callable=MockStream)
-@patch("con_duct.duct_main.sys.stdout", new_callable=MockStream)
+@patch("con_duct._output.TailPipe")
+@patch("con_duct._output.LogPaths")
+@patch("con_duct._output.sys.stderr", new_callable=MockStream)
+@patch("con_duct._output.sys.stdout", new_callable=MockStream)
 def test_prepare_outputs_capture_all_output_all(
     mock_stdout: MockStream,
     mock_stderr: MockStream,

--- a/test/duct_main/test_tailpipe.py
+++ b/test/duct_main/test_tailpipe.py
@@ -5,7 +5,7 @@ import tempfile
 from unittest.mock import patch
 import pytest
 from utils import MockStream
-from con_duct.duct_main import TailPipe
+from con_duct._output import TailPipe
 
 # 10^7 line fixture is about 70MB
 FIXTURE_LIST = [f"ten_{i}" for i in range(1, 8)]


### PR DESCRIPTION
## Summary
- Extract I/O utilities to new `_output.py` module:
  - `TailPipe` class
  - `prepare_outputs` function
  - `safe_close_files` function
  - `remove_files` function
- Update test imports and patches to use new module location
- Remove unused `Iterable` import from `duct_main.py`

Part of #372

## Test plan
- [x] All 346 tests pass
- [x] Lint passes
- [x] Typing passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)