### PR TITLE
Add `--output-prefix` flag to `con-duct ls`

### DIFF
--- a/src/con_duct/_duct_main.py
+++ b/src/con_duct/_duct_main.py
@@ -16,23 +16,6 @@ __version__ = version("con-duct")
 
 lgr = logging.getLogger("con-duct")
 
-DUCT_OUTPUT_PREFIX = os.getenv("DUCT_OUTPUT_PREFIX", ".duct/logs/{datetime}-{pid}_")
-EXECUTION_SUMMARY_FORMAT = (
-    "Summary:\n"
-    "Exit Code: {exit_code!E}\n"
-    "Command: {command}\n"
-    "Log files location: {logs_prefix}\n"
-    "Wall Clock Time: {wall_clock_time:.3f} sec\n"
-    "Memory Peak Usage (RSS): {peak_rss!S}\n"
-    "Memory Average Usage (RSS): {average_rss!S}\n"
-    "Virtual Memory Peak Usage (VSZ): {peak_vsz!S}\n"
-    "Virtual Memory Average Usage (VSZ): {average_vsz!S}\n"
-    "Memory Peak Percentage: {peak_pmem:.2f!N}%\n"
-    "Memory Average Percentage: {average_pmem:.2f!N}%\n"
-    "CPU Peak Usage: {peak_pcpu:.2f!N}%\n"
-    "Average CPU Usage: {average_pcpu:.2f!N}%\n"
-)
-
 
 def execute(
     command: str,

--- a/src/con_duct/cli.py
+++ b/src/con_duct/cli.py
@@ -7,12 +7,28 @@ import sys
 import textwrap
 from typing import List, Optional
 from con_duct import __version__
-from con_duct._duct_main import DUCT_OUTPUT_PREFIX, EXECUTION_SUMMARY_FORMAT
 from con_duct._duct_main import execute as duct_execute
 from con_duct._models import Outputs, RecordTypes, SessionMode
 from con_duct.ls import LS_FIELD_CHOICES, ls
 from con_duct.plot import matplotlib_plot
 from con_duct.pprint_json import pprint_json
+
+DEFAULT_OUTPUT_PREFIX = ".duct/logs/{datetime}-{pid}_"
+DEFAULT_SUMMARY_FORMAT = (
+    "Summary:\n"
+    "Exit Code: {exit_code!E}\n"
+    "Command: {command}\n"
+    "Log files location: {logs_prefix}\n"
+    "Wall Clock Time: {wall_clock_time:.3f} sec\n"
+    "Memory Peak Usage (RSS): {peak_rss!S}\n"
+    "Memory Average Usage (RSS): {average_rss!S}\n"
+    "Virtual Memory Peak Usage (VSZ): {peak_vsz!S}\n"
+    "Virtual Memory Average Usage (VSZ): {average_vsz!S}\n"
+    "Memory Peak Percentage: {peak_pmem:.2f!N}%\n"
+    "Memory Average Percentage: {average_pmem:.2f!N}%\n"
+    "CPU Peak Usage: {peak_pcpu:.2f!N}%\n"
+    "Average CPU Usage: {average_pcpu:.2f!N}%\n"
+)
 
 # Default .env file search paths (in precedence order)
 DEFAULT_CONFIG_PATHS_LIST = (
@@ -264,7 +280,7 @@ def _create_run_parser() -> argparse.ArgumentParser:
         "-p",
         "--output-prefix",
         type=str,
-        default=DUCT_OUTPUT_PREFIX,
+        default=os.getenv("DUCT_OUTPUT_PREFIX", DEFAULT_OUTPUT_PREFIX),
         help="File string format to be used as a prefix for the files -- the captured "
         "stdout and stderr and the resource usage logs. The understood variables are "
         "{datetime} and {pid}. "
@@ -274,7 +290,7 @@ def _create_run_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--summary-format",
         type=str,
-        default=os.getenv("DUCT_SUMMARY_FORMAT", EXECUTION_SUMMARY_FORMAT),
+        default=os.getenv("DUCT_SUMMARY_FORMAT", DEFAULT_SUMMARY_FORMAT),
         help="Output template to use when printing the summary following execution. "
         "Accepts custom conversion flags: "
         "!S: Converts filesizes to human readable units, green if measured, red if None. "
@@ -455,6 +471,13 @@ def _create_ls_parser() -> argparse.ArgumentParser:
         "--reverse",
         action="store_true",
         help="List entries in reverse order (most recent first).",
+    )
+    parser.add_argument(
+        "-p",
+        "--output-prefix",
+        default=os.getenv("DUCT_OUTPUT_PREFIX", DEFAULT_OUTPUT_PREFIX),
+        help="Output prefix pattern used to glob for log files when no paths are given. "
+        "Defaults to DUCT_OUTPUT_PREFIX so ls searches where logs are written.",
     )
     return parser
 

--- a/src/con_duct/ls.py
+++ b/src/con_duct/ls.py
@@ -219,7 +219,7 @@ def pyout_ls(run_data_list: List[OrderedDict[str, Any]], enable_colors: bool) ->
 
 def ls(args: argparse.Namespace) -> int:
     if not args.paths:
-        # The default search prefix contains {datetime_filesafe}, {pid}, etc.
+        # The default search prefix contains {datetime}, {pid}, etc.
         # Strip from the first '{' onward to get a static glob prefix.
         try:
             prefix = args.output_prefix[: args.output_prefix.index("{")]

--- a/src/con_duct/ls.py
+++ b/src/con_duct/ls.py
@@ -7,7 +7,6 @@ import re
 from types import ModuleType
 from typing import Any, Dict, List, Optional
 from con_duct._constants import __schema_version__
-from con_duct._duct_main import DUCT_OUTPUT_PREFIX
 from con_duct._formatter import SummaryFormatter
 from con_duct._utils import parse_version
 from con_duct.json_utils import is_info_file
@@ -220,7 +219,13 @@ def pyout_ls(run_data_list: List[OrderedDict[str, Any]], enable_colors: bool) ->
 
 def ls(args: argparse.Namespace) -> int:
     if not args.paths:
-        pattern = f"{DUCT_OUTPUT_PREFIX[:DUCT_OUTPUT_PREFIX.index('{')]}*"
+        # The default search prefix contains {datetime_filesafe}, {pid}, etc.
+        # Strip from the first '{' onward to get a static glob prefix.
+        try:
+            prefix = args.output_prefix[: args.output_prefix.index("{")]
+        except ValueError:
+            prefix = args.output_prefix
+        pattern = f"{prefix}*"
         args.paths = [p for p in glob.glob(pattern)]
 
     if args.format == "auto":

--- a/src/con_duct/ls.py
+++ b/src/con_duct/ls.py
@@ -6,7 +6,7 @@ import logging
 import re
 from types import ModuleType
 from typing import Any, Dict, List, Optional
-from con_duct._constants import __schema_version__
+from con_duct._constants import SUFFIXES, __schema_version__
 from con_duct._formatter import SummaryFormatter
 from con_duct._utils import parse_version
 from con_duct.json_utils import is_info_file
@@ -225,7 +225,7 @@ def ls(args: argparse.Namespace) -> int:
             prefix = args.output_prefix[: args.output_prefix.index("{")]
         except ValueError:
             prefix = args.output_prefix
-        pattern = f"{prefix}*"
+        pattern = f"{prefix}*{SUFFIXES['info']}"
         args.paths = [p for p in glob.glob(pattern)]
 
     if args.format == "auto":

--- a/test/duct_main/test_aggregation.py
+++ b/test/duct_main/test_aggregation.py
@@ -4,9 +4,9 @@ import os
 from typing import cast
 from unittest import mock
 import pytest
-from con_duct._duct_main import EXECUTION_SUMMARY_FORMAT
 from con_duct._models import ProcessStats, Sample
 from con_duct._tracker import Report
+from con_duct.cli import DEFAULT_SUMMARY_FORMAT
 
 stat0 = ProcessStats(
     pcpu=0.0,
@@ -70,7 +70,7 @@ def test_aggregation_num_samples_increment(mock_log_paths: mock.MagicMock) -> No
     mock_log_paths.prefix = "mock_prefix"
     cwd = os.getcwd()
     report = Report(
-        "_cmd", [], mock_log_paths, EXECUTION_SUMMARY_FORMAT, cwd, clobber=False
+        "_cmd", [], mock_log_paths, DEFAULT_SUMMARY_FORMAT, cwd, clobber=False
     )
     assert report.current_sample is None
     assert report.full_run_stats.averages.num_samples == 0
@@ -98,7 +98,7 @@ def test_aggregation_single_sample_sanity(mock_log_paths: mock.MagicMock) -> Non
     mock_log_paths.prefix = "mock_prefix"
     cwd = os.getcwd()
     report = Report(
-        "_cmd", [], mock_log_paths, EXECUTION_SUMMARY_FORMAT, cwd, clobber=False
+        "_cmd", [], mock_log_paths, DEFAULT_SUMMARY_FORMAT, cwd, clobber=False
     )
     assert report.current_sample is None
     assert report.full_run_stats.averages.num_samples == 0
@@ -135,7 +135,7 @@ def test_aggregation_single_stat_multiple_samples_sanity(
     mock_log_paths.prefix = "mock_prefix"
     cwd = os.getcwd()
     report = Report(
-        "_cmd", [], mock_log_paths, EXECUTION_SUMMARY_FORMAT, cwd, clobber=False
+        "_cmd", [], mock_log_paths, DEFAULT_SUMMARY_FORMAT, cwd, clobber=False
     )
     assert report.current_sample is None
     assert report.full_run_stats.averages.num_samples == 0
@@ -184,7 +184,7 @@ def test_aggregation_averages(mock_log_paths: mock.MagicMock) -> None:
     mock_log_paths.prefix = "mock_prefix"
     cwd = os.getcwd()
     report = Report(
-        "_cmd", [], mock_log_paths, EXECUTION_SUMMARY_FORMAT, cwd, clobber=False
+        "_cmd", [], mock_log_paths, DEFAULT_SUMMARY_FORMAT, cwd, clobber=False
     )
     assert report.current_sample is None
     assert report.full_run_stats.averages.num_samples == 0
@@ -256,7 +256,7 @@ def test_aggregation_current_ave_diverges_from_total_ave(
     mock_log_paths.prefix = "mock_prefix"
     cwd = os.getcwd()
     report = Report(
-        "_cmd", [], mock_log_paths, EXECUTION_SUMMARY_FORMAT, cwd, clobber=False
+        "_cmd", [], mock_log_paths, DEFAULT_SUMMARY_FORMAT, cwd, clobber=False
     )
     assert report.current_sample is None
     assert report.full_run_stats.averages.num_samples == 0
@@ -323,7 +323,7 @@ def test_aggregation_many_samples(
     mock_log_paths.prefix = "mock_prefix"
     cwd = os.getcwd()
     report = Report(
-        "_cmd", [], mock_log_paths, EXECUTION_SUMMARY_FORMAT, cwd, clobber=False
+        "_cmd", [], mock_log_paths, DEFAULT_SUMMARY_FORMAT, cwd, clobber=False
     )
     assert report.current_sample is None
     assert report.full_run_stats.averages.num_samples == 0
@@ -364,7 +364,7 @@ def test_aggregation_sample_no_pids(mock_log_paths: mock.MagicMock) -> None:
     mock_log_paths.prefix = "mock_prefix"
     cwd = os.getcwd()
     report = Report(
-        "_cmd", [], mock_log_paths, EXECUTION_SUMMARY_FORMAT, cwd, clobber=False
+        "_cmd", [], mock_log_paths, DEFAULT_SUMMARY_FORMAT, cwd, clobber=False
     )
     # When there are no pids, finalization should be triggered because the exe is finished,
     # so a Sample with no PIDs should never be passed to update_from_sample.
@@ -379,7 +379,7 @@ def test_aggregation_no_false_peak(mock_log_paths: mock.MagicMock) -> None:
     mock_log_paths.prefix = "mock_prefix"
     cwd = os.getcwd()
     report = Report(
-        "_cmd", [], mock_log_paths, EXECUTION_SUMMARY_FORMAT, cwd, clobber=False
+        "_cmd", [], mock_log_paths, DEFAULT_SUMMARY_FORMAT, cwd, clobber=False
     )
     sample1.add_pid(1, deepcopy(stat100))
     sample1.add_pid(2, deepcopy(stat0))

--- a/test/duct_main/test_report.py
+++ b/test/duct_main/test_report.py
@@ -6,9 +6,9 @@ import os
 import subprocess
 from unittest import mock
 import pytest
-from con_duct._duct_main import EXECUTION_SUMMARY_FORMAT
 from con_duct._models import Averages, ProcessStats, Sample
 from con_duct._tracker import Report
+from con_duct.cli import DEFAULT_SUMMARY_FORMAT
 
 stat0 = ProcessStats(
     pcpu=0.0,
@@ -219,7 +219,7 @@ def test_system_info_sanity(mock_log_paths: mock.MagicMock) -> None:
     mock_log_paths.prefix = "mock_prefix"
     cwd = os.getcwd()
     report = Report(
-        "_cmd", [], mock_log_paths, EXECUTION_SUMMARY_FORMAT, cwd, clobber=False
+        "_cmd", [], mock_log_paths, DEFAULT_SUMMARY_FORMAT, cwd, clobber=False
     )
     report.get_system_info()
     assert report.system_info is not None
@@ -242,7 +242,7 @@ def test_gpu_parsing_green(
     ).encode("utf-8")
     cwd = os.getcwd()
     report = Report(
-        "_cmd", [], mock_log_paths, EXECUTION_SUMMARY_FORMAT, cwd, clobber=False
+        "_cmd", [], mock_log_paths, DEFAULT_SUMMARY_FORMAT, cwd, clobber=False
     )
     report.get_system_info()
     assert report.gpus is not None
@@ -271,7 +271,7 @@ def test_gpu_call_error(
     mock_sp.side_effect = subprocess.CalledProcessError(1, "errrr")
     cwd = os.getcwd()
     report = Report(
-        "_cmd", [], mock_log_paths, EXECUTION_SUMMARY_FORMAT, cwd, clobber=False
+        "_cmd", [], mock_log_paths, DEFAULT_SUMMARY_FORMAT, cwd, clobber=False
     )
     report.get_system_info()
     assert report.gpus is None
@@ -294,7 +294,7 @@ def test_gpu_parse_error(
     ).encode("utf-8")
     cwd = os.getcwd()
     report = Report(
-        "_cmd", [], mock_log_paths, EXECUTION_SUMMARY_FORMAT, cwd, clobber=False
+        "_cmd", [], mock_log_paths, DEFAULT_SUMMARY_FORMAT, cwd, clobber=False
     )
     report.get_system_info()
     assert report.gpus is None

--- a/test/test_ls.py
+++ b/test/test_ls.py
@@ -228,7 +228,7 @@ class TestLS(unittest.TestCase):
                 format=fmt,
                 func=ls,
                 reverse=False,
-                output_prefix=".duct/logs/{datetime_filesafe}-{pid}_",
+                output_prefix=".duct/logs/{datetime}-{pid}_",
             )
         buf = StringIO()
         with contextlib.redirect_stdout(buf):
@@ -261,7 +261,7 @@ class TestLS(unittest.TestCase):
             format="summaries",
             func=ls,
             reverse=False,
-            output_prefix=".duct/logs/{datetime_filesafe}-{pid}_",
+            output_prefix=".duct/logs/{datetime}-{pid}_",
         )
         result = self._run_ls(paths, "summaries", args)
 
@@ -412,7 +412,7 @@ class TestLS(unittest.TestCase):
             format="json",
             func=ls,
             reverse=True,
-            output_prefix=".duct/logs/{datetime_filesafe}-{pid}_",
+            output_prefix=".duct/logs/{datetime}-{pid}_",
         )
         result_reversed = self._run_ls(paths, "json", args)
         parsed_reversed = json.loads(result_reversed)

--- a/test/utils.py
+++ b/test/utils.py
@@ -14,15 +14,15 @@ def run_duct_command(cli_args: list[str], **kwargs: Any) -> int:
     Returns:
         Exit code from the executed command
     """
-    from con_duct._duct_main import DUCT_OUTPUT_PREFIX, EXECUTION_SUMMARY_FORMAT
     from con_duct._duct_main import execute as duct_execute
     from con_duct._models import Outputs, RecordTypes, SessionMode
+    from con_duct.cli import DEFAULT_OUTPUT_PREFIX, DEFAULT_SUMMARY_FORMAT
 
     command = cli_args[0]
     command_args = cli_args[1:] if len(cli_args) > 1 else []
 
     defaults = {
-        "output_prefix": DUCT_OUTPUT_PREFIX,
+        "output_prefix": DEFAULT_OUTPUT_PREFIX,
         "sample_interval": 1.0,
         "report_interval": 60.0,
         "fail_time": 3.0,
@@ -30,7 +30,7 @@ def run_duct_command(cli_args: list[str], **kwargs: Any) -> int:
         "capture_outputs": Outputs.ALL,
         "outputs": Outputs.ALL,
         "record_types": RecordTypes.ALL,
-        "summary_format": EXECUTION_SUMMARY_FORMAT,
+        "summary_format": DEFAULT_SUMMARY_FORMAT,
         "colors": False,
         "mode": SessionMode.NEW_SESSION,
         "message": "",


### PR DESCRIPTION
Internal changes:
- Move `DUCT_OUTPUT_PREFIX` and `EXECUTION_SUMMARY_FORMAT` from `duct_main.py` to `cli.py`, renamed to `DEFAULT_OUTPUT_PREFIX` and `DEFAULT_SUMMARY_FORMAT`
- Break circular import by adding `--output-prefix` / `-p` to `con-duct ls`, so `ls.py` receives the prefix via args instead of importing it from `duct_main`

Fix latent bug:
- the output prefix default was evaluated at import time (before `.env` files were loaded); now `os.getenv()` runs at parser creation time inside `main()`

Closes #386

🤖 Generated with [Claude Code](https://claude.com/claude-code)