### PR TITLE
pp: humanize memory_total under -H

### DIFF
--- a/src/con_duct/pprint_json.py
+++ b/src/con_duct/pprint_json.py
@@ -20,6 +20,7 @@ def get_field_conversion_mapping() -> dict[str, str]:
         "average_vsz": "S",
         "peak_pcpu": "P",
         "peak_pmem": "P",
+        "memory_total": "S",
         "peak_rss": "S",
         "peak_vsz": "S",
         "wall_clock_time": "T",

--- a/test/test_pprint.py
+++ b/test/test_pprint.py
@@ -84,6 +84,11 @@ class TestPPrintHumanization(unittest.TestCase):
         assert result == "1.0 MB"
 
         result = pprint_json._apply_conversion(
+            "memory_total", 1081801371648, field_mapping, formatter
+        )
+        assert result == "1.1 TB"
+
+        result = pprint_json._apply_conversion(
             "wall_clock_time", 3661.5, field_mapping, formatter
         )
         assert result == "1h 1m 1.5s"


### PR DESCRIPTION
`con-duct pp -H` humanizes byte-count fields like `peak_rss` and
`peak_vsz` but missed `memory_total` (under `system`), so users saw a
raw integer like `1081801371648` next to humanized siblings.

Adds `memory_total` to the per-key conversion mapping in
`pprint_json.get_field_conversion_mapping()` (uses the `S` size
conversion) and extends `test_apply_conversion_with_numbers` to cover
it.

Closes con/duct#412.
