### PR TITLE
fix: clean error on output prefix collision instead of traceback

### DIFF
--- a/src/con_duct/_duct_main.py
+++ b/src/con_duct/_duct_main.py
@@ -60,7 +60,11 @@ def execute(
         )
 
     log_paths = LogPaths.create(output_prefix, pid=os.getpid())
-    log_paths.prepare_paths(clobber, capture_outputs)
+    try:
+        log_paths.prepare_paths(clobber, capture_outputs)
+    except FileExistsError as e:
+        lgr.error("%s", e)
+        return 1
     stdout, stderr = prepare_outputs(capture_outputs, outputs, log_paths)
     stdout_file: TextIO | IO[bytes] | int | None
     if isinstance(stdout, TailPipe):

--- a/test/duct_main/test_execution.py
+++ b/test/duct_main/test_execution.py
@@ -363,3 +363,17 @@ def test_no_message_in_json_output(temp_output_dir: str) -> None:
 
     assert "message" in info_dict
     assert info_dict["message"] == ""
+
+
+def test_execute_existing_files_no_clobber(
+    temp_output_dir: str, caplog: pytest.LogCaptureFixture
+) -> None:
+    Path(temp_output_dir, SUFFIXES["info"]).write_text("pre-existing")
+    with caplog.at_level(logging.ERROR):
+        assert run_duct_command(["echo", "hi"], output_prefix=temp_output_dir) == 1
+    assert "Conflicting files:" in caplog.text
+    assert_files(
+        temp_output_dir,
+        [SUFFIXES["stdout"], SUFFIXES["stderr"], SUFFIXES["usage"]],
+        exists=False,
+    )


### PR DESCRIPTION
Running `duct` (or `con-duct run`) against an output prefix where files already exist — without `--clobber` — prints a full Python traceback ending in `FileExistsError`, exiting 1. The exception's message is already user-facing quality (it lists the conflicting paths and tells the user to pass `--clobber`), but the traceback wrapper makes it look like duct crashed.

Catches `FileExistsError` at the call site of `LogPaths.prepare_paths()` in `_duct_main.execute()`, logs the existing message at ERROR level via `lgr`, and returns 1. Mirrors the existing `FileNotFoundError` handler a few lines below in the same function. The exception and its message in `_models.py` are unchanged; exit code is unchanged (1). Adds `test_execute_existing_files_no_clobber` to `test/duct_main/test_execution.py` mirroring the shape of `test_execute_unknown_command`: covers exit code, ERROR log content, and that the never-created sibling outputs are not spuriously created.

Closes con/duct#410.
