### PR TITLE
fix: emit deprecation warning for {datetime_filesafe} format field

### DIFF
--- a/src/con_duct/_models.py
+++ b/src/con_duct/_models.py
@@ -9,6 +9,7 @@ from enum import Enum
 import logging
 import os
 import re
+import string
 from typing import Any, Optional
 from con_duct._constants import SUFFIXES
 from con_duct._utils import assert_num
@@ -129,6 +130,13 @@ class LogPaths:
 
     @classmethod
     def create(cls, output_prefix: str, pid: None | int = None) -> LogPaths:
+        if any(
+            field_name == "datetime_filesafe"
+            for _, field_name, _, _ in string.Formatter().parse(output_prefix)
+        ):
+            lgr.warning(
+                "{datetime_filesafe} in --output-prefix is deprecated; use {datetime} instead"
+            )
         datetime_filesafe = datetime.now().strftime("%Y.%m.%dT%H.%M.%S")
         formatted_prefix = output_prefix.format(
             pid=pid,

--- a/test/duct_main/test_log_paths.py
+++ b/test/duct_main/test_log_paths.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import asdict
+import logging
 import os
 import re
 from unittest.mock import MagicMock, call, patch
@@ -14,12 +15,34 @@ def test_log_paths_datetime_prefix() -> None:
         assert re.match(pattern, path) is not None
 
 
-def test_log_paths_deprecated_datetime_filesafe_prefix() -> None:
-    """Ensure deprecated {datetime_filesafe} format field still works."""
-    log_paths = LogPaths.create("start_{datetime_filesafe}")
+def test_log_paths_deprecated_datetime_filesafe_prefix(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Ensure deprecated {datetime_filesafe} format field still works and warns."""
+    with caplog.at_level(logging.WARNING):
+        log_paths = LogPaths.create("start_{datetime_filesafe}")
     pattern = r"^start_\d{4}\.\d{2}\.\d{2}T\d{2}\.\d{2}\.\d{2}.*"
     for path in asdict(log_paths).values():
         assert re.match(pattern, path) is not None
+    assert "{datetime_filesafe}" in caplog.text
+
+
+def test_log_paths_no_warning_for_escaped_datetime_filesafe(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Escaped braces {{datetime_filesafe}} are literal text; no warning should fire."""
+    with caplog.at_level(logging.WARNING):
+        LogPaths.create("prefix_{{datetime_filesafe}}_suffix_")
+    assert "{datetime_filesafe}" not in caplog.text
+
+
+def test_log_paths_datetime_filesafe_warning_with_format_spec(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Warning fires when {datetime_filesafe} has a format spec (substring check would miss this)."""
+    with caplog.at_level(logging.WARNING):
+        LogPaths.create("padded_{datetime_filesafe:>20}")
+    assert "{datetime_filesafe}" in caplog.text
 
 
 def test_log_paths_pid_prefix() -> None:


### PR DESCRIPTION
PR #375 (January 2026) renamed the `{datetime_filesafe}` placeholder in `--output-prefix` to `{datetime}`. The legacy name was retained as a backward-compat shim in `LogPaths.create()` (`_models.py`) with a comment noting "It should be removed eventually" — but users on the legacy name receive no signal that they're on a deprecated placeholder, so they won't migrate before the shim is dropped.

Adds a substring check at the top of `LogPaths.create()`: if `{datetime_filesafe}` appears in `output_prefix`, emit `lgr.warning("{datetime_filesafe} in --output-prefix is deprecated; use {datetime} instead")` once per invocation. Behavior is otherwise unchanged. The existing `test_log_paths_deprecated_datetime_filesafe_prefix` is extended (per datalad CONTRIBUTING.md's "minimal assertion" guidance) to assert the warning text appears in `caplog`.

Closes con/duct#411.
