### PR TITLE
bf: validate --eval-filter up-front, fail with a clear error (#440)

### DIFF
--- a/src/con_duct/ls.py
+++ b/src/con_duct/ls.py
@@ -4,8 +4,8 @@ import glob
 import json
 import logging
 import re
-from types import ModuleType
-from typing import Any, Dict, List, Optional
+from types import CodeType, ModuleType
+from typing import Any, Dict, List, Optional, Union
 from con_duct._constants import __schema_version__
 from con_duct._duct_main import DUCT_OUTPUT_PREFIX
 from con_duct._formatter import SummaryFormatter
@@ -68,9 +68,36 @@ LS_FIELD_CHOICES: List[str] = (
 MINIMUM_SCHEMA_VERSION: str = "0.2.0"
 
 
+def compile_eval_filter(eval_filter: Optional[str]) -> Optional[CodeType]:
+    """Compile an --eval-filter expression up-front.
+
+    Compiling once (rather than re-parsing per file) lets us fail fast with a
+    clear error before any files are opened, and mis-classified errors like a
+    stray U+00A0 (non-breaking space) in the expression no longer surface as
+    per-file "Failed to load file" warnings.
+    """
+    if eval_filter is None:
+        return None
+    try:
+        return compile(eval_filter, "<eval-filter>", "eval")
+    except SyntaxError as exc:
+        raise ValueError(
+            f"Invalid --eval-filter expression {eval_filter!r}: {exc}. "
+            "Check for hidden non-printable characters (e.g. U+00A0 "
+            "non-breaking space produced by macOS Option+Space or copy-paste "
+            "from a browser/document)."
+        ) from exc
+
+
 def load_duct_runs(
-    info_files: List[str], eval_filter: Optional[str] = None
+    info_files: List[str],
+    eval_filter: Optional[Union[str, CodeType]] = None,
 ) -> List[Dict[str, Any]]:
+    compiled_filter = (
+        compile_eval_filter(eval_filter)
+        if eval_filter is None or isinstance(eval_filter, str)
+        else eval_filter
+    )
     loaded: List[Dict[str, Any]] = []
     for info_file in info_files:
         with open(info_file) as file:
@@ -87,8 +114,10 @@ def load_duct_runs(
                     )
                     continue
                 ensure_compliant_schema(this)
-                if eval_filter is not None and not (
-                    eval_results := eval(eval_filter, _flatten_dict(this), dict(re=re))
+                if compiled_filter is not None and not (
+                    eval_results := eval(
+                        compiled_filter, _flatten_dict(this), dict(re=re)
+                    )
                 ):
                     lgr.debug(
                         "Filtering out %s due to filter results matching: %s",
@@ -219,6 +248,15 @@ def pyout_ls(run_data_list: List[OrderedDict[str, Any]], enable_colors: bool) ->
 
 
 def ls(args: argparse.Namespace) -> int:
+    # Validate the filter expression up front so a typo (or a hidden
+    # non-printable character like U+00A0) errors out cleanly, before we
+    # glob or open any files.
+    try:
+        compiled_filter = compile_eval_filter(args.eval_filter)
+    except ValueError as exc:
+        lgr.error("%s", exc)
+        return 2
+
     if not args.paths:
         pattern = f"{DUCT_OUTPUT_PREFIX[:DUCT_OUTPUT_PREFIX.index('{')]}*"
         args.paths = [p for p in glob.glob(pattern)]
@@ -230,7 +268,7 @@ def ls(args: argparse.Namespace) -> int:
         enable_colors=False if args.format == "pyout" else args.colors
     )
     info_files = [path for path in args.paths if is_info_file(path)]
-    run_data_raw = load_duct_runs(info_files, args.eval_filter)
+    run_data_raw = load_duct_runs(info_files, compiled_filter)
     output_rows = process_run_data(run_data_raw, args.fields, formatter)
 
     if args.reverse:

--- a/src/con_duct/ls.py
+++ b/src/con_duct/ls.py
@@ -5,7 +5,7 @@ import json
 import logging
 import re
 from types import CodeType, ModuleType
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional
 from con_duct._constants import __schema_version__
 from con_duct._duct_main import DUCT_OUTPUT_PREFIX
 from con_duct._formatter import SummaryFormatter
@@ -91,13 +91,15 @@ def compile_eval_filter(eval_filter: Optional[str]) -> Optional[CodeType]:
 
 def load_duct_runs(
     info_files: List[str],
-    eval_filter: Optional[Union[str, CodeType]] = None,
+    eval_filter: Optional[CodeType] = None,
 ) -> List[Dict[str, Any]]:
-    compiled_filter = (
-        compile_eval_filter(eval_filter)
-        if eval_filter is None or isinstance(eval_filter, str)
-        else eval_filter
-    )
+    """Load the given info.json files, keeping those matching `eval_filter`.
+
+    Args:
+        info_files: Paths to `info.json` files to load.
+        eval_filter: Filter expression already compiled by
+            `compile_eval_filter()`; `None` keeps every run.
+    """
     loaded: List[Dict[str, Any]] = []
     for info_file in info_files:
         with open(info_file) as file:
@@ -114,10 +116,8 @@ def load_duct_runs(
                     )
                     continue
                 ensure_compliant_schema(this)
-                if compiled_filter is not None and not (
-                    eval_results := eval(
-                        compiled_filter, _flatten_dict(this), dict(re=re)
-                    )
+                if eval_filter is not None and not (
+                    eval_results := eval(eval_filter, _flatten_dict(this), dict(re=re))
                 ):
                     lgr.debug(
                         "Filtering out %s due to filter results matching: %s",
@@ -255,7 +255,7 @@ def ls(args: argparse.Namespace) -> int:
         compiled_filter = compile_eval_filter(args.eval_filter)
     except ValueError as exc:
         lgr.error("%s", exc)
-        return 2
+        return 2  # usage error
 
     if not args.paths:
         pattern = f"{DUCT_OUTPUT_PREFIX[:DUCT_OUTPUT_PREFIX.index('{')]}*"

--- a/src/con_duct/ls.py
+++ b/src/con_duct/ls.py
@@ -72,7 +72,7 @@ def compile_eval_filter(eval_filter: Optional[str]) -> Optional[CodeType]:
     """Compile an --eval-filter expression up-front.
 
     Compiling once (rather than re-parsing per file) lets us fail fast with a
-    clear error before any files are opened, and mis-classified errors like a
+    clear error before any files are opened, and misclassified errors like a
     stray U+00A0 (non-breaking space) in the expression no longer surface as
     per-file "Failed to load file" warnings.
     """

--- a/test/test_ls.py
+++ b/test/test_ls.py
@@ -15,6 +15,7 @@ from con_duct.ls import (
     MINIMUM_SCHEMA_VERSION,
     _flatten_dict,
     _restrict_row,
+    compile_eval_filter,
     ensure_compliant_schema,
     load_duct_runs,
     ls,
@@ -162,6 +163,69 @@ def test_load_duct_runs_mixed_empty_and_valid_files(
     assert len([r for r in caplog.records if r.levelname == "DEBUG"]) == 1
     assert not any(r for r in caplog.records if r.levelname == "WARNING")
     assert "Skipping empty file" in caplog.text
+
+
+def test_compile_eval_filter_none_returns_none() -> None:
+    assert compile_eval_filter(None) is None
+
+
+def test_compile_eval_filter_valid() -> None:
+    code = compile_eval_filter("exit_code == 0")
+    assert code is not None
+    assert eval(code, {"exit_code": 0}) is True
+    assert eval(code, {"exit_code": 1}) is False
+
+
+def test_compile_eval_filter_rejects_nbsp() -> None:
+    """Regression test for gh-440: a U+00A0 in the filter must fail
+    up-front with a clear message that mentions the character, rather
+    than surfacing later as per-file "Failed to load file" warnings."""
+    # Note the U+00A0 non-breaking space between "and" and "exit_code",
+    # exactly as reported by a macOS user in gh-440 (Option+Space).
+    bad_expr = '"fmriprep" in command and exit_code == 1'
+    with pytest.raises(ValueError, match="U\\+00A0"):
+        compile_eval_filter(bad_expr)
+
+
+def test_compile_eval_filter_rejects_syntax_error() -> None:
+    with pytest.raises(ValueError, match="Invalid --eval-filter"):
+        compile_eval_filter("this is not valid python")
+
+
+def test_load_duct_runs_fails_fast_on_bad_filter(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A bad filter must raise before any file is opened, not surface
+    once per file as a "Failed to load" warning."""
+    with patch("builtins.open") as mock_open_fn:
+        with pytest.raises(ValueError, match="U\\+00A0"):
+            load_duct_runs(
+                ["/test/a_info.json", "/test/b_info.json"],
+                eval_filter='"x" in command and exit_code == 1',
+            )
+    mock_open_fn.assert_not_called()
+    # And nothing was mis-classified as a per-file load failure.
+    assert not any("Failed to load file" in r.message for r in caplog.records)
+
+
+def test_ls_exits_cleanly_on_bad_filter(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """`con-duct ls` should error out with a clear message and non-zero
+    exit code when --eval-filter has a syntax error, without traceback."""
+    args = argparse.Namespace(
+        paths=["/no/such/file_info.json"],
+        colors=False,
+        fields=["prefix"],
+        eval_filter='"x" in command and exit_code == 1',
+        format="summaries",
+        func=ls,
+        reverse=False,
+    )
+    with caplog.at_level(logging.ERROR):
+        rc = ls(args)
+    assert rc == 2
+    assert any("U+00A0" in r.message for r in caplog.records)
 
 
 class TestLS(unittest.TestCase):

--- a/test/test_ls.py
+++ b/test/test_ls.py
@@ -192,29 +192,15 @@ def test_compile_eval_filter_rejects_syntax_error() -> None:
         compile_eval_filter("this is not valid python")
 
 
-def test_load_duct_runs_fails_fast_on_bad_filter(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """A bad filter must raise before any file is opened, not surface
-    once per file as a "Failed to load" warning."""
-    with patch("builtins.open") as mock_open_fn:
-        with pytest.raises(ValueError, match="U\\+00A0"):
-            load_duct_runs(
-                ["/test/a_info.json", "/test/b_info.json"],
-                eval_filter='"x" in command and\u00a0exit_code == 1',
-            )
-    mock_open_fn.assert_not_called()
-    # And nothing was misclassified as a per-file load failure.
-    assert not any("Failed to load file" in r.message for r in caplog.records)
-
-
 def test_ls_exits_cleanly_on_bad_filter(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """`con-duct ls` should error out with a clear message and non-zero
-    exit code when --eval-filter has a syntax error, without traceback."""
+    exit code when --eval-filter has a syntax error, without traceback --
+    and before any file is opened, so the failure is never misattributed
+    to a log file as a "Failed to load" warning."""
     args = argparse.Namespace(
-        paths=["/no/such/file_info.json"],
+        paths=["/no/such/file_info.json", "/no/such/other_info.json"],
         colors=False,
         fields=["prefix"],
         eval_filter='"x" in command and\u00a0exit_code == 1',
@@ -223,9 +209,12 @@ def test_ls_exits_cleanly_on_bad_filter(
         reverse=False,
     )
     with caplog.at_level(logging.ERROR):
-        rc = ls(args)
+        with patch("builtins.open") as mock_open_fn:
+            rc = ls(args)
     assert rc == 2
+    mock_open_fn.assert_not_called()
     assert any("U+00A0" in r.message for r in caplog.records)
+    assert not any("Failed to load file" in r.message for r in caplog.records)
 
 
 class TestLS(unittest.TestCase):

--- a/test/test_ls.py
+++ b/test/test_ls.py
@@ -182,7 +182,7 @@ def test_compile_eval_filter_rejects_nbsp() -> None:
     than surfacing later as per-file "Failed to load file" warnings."""
     # Note the U+00A0 non-breaking space between "and" and "exit_code",
     # exactly as reported by a macOS user in gh-440 (Option+Space).
-    bad_expr = '"fmriprep" in command and exit_code == 1'
+    bad_expr = '"fmriprep" in command and\u00a0exit_code == 1'
     with pytest.raises(ValueError, match="U\\+00A0"):
         compile_eval_filter(bad_expr)
 
@@ -201,10 +201,10 @@ def test_load_duct_runs_fails_fast_on_bad_filter(
         with pytest.raises(ValueError, match="U\\+00A0"):
             load_duct_runs(
                 ["/test/a_info.json", "/test/b_info.json"],
-                eval_filter='"x" in command and exit_code == 1',
+                eval_filter='"x" in command and\u00a0exit_code == 1',
             )
     mock_open_fn.assert_not_called()
-    # And nothing was mis-classified as a per-file load failure.
+    # And nothing was misclassified as a per-file load failure.
     assert not any("Failed to load file" in r.message for r in caplog.records)
 
 
@@ -217,7 +217,7 @@ def test_ls_exits_cleanly_on_bad_filter(
         paths=["/no/such/file_info.json"],
         colors=False,
         fields=["prefix"],
-        eval_filter='"x" in command and exit_code == 1',
+        eval_filter='"x" in command and\u00a0exit_code == 1',
         format="summaries",
         func=ls,
         reverse=False,


### PR DESCRIPTION
- Fixes #440.

## Summary

`con-duct ls -e EXPR` used to call `eval(EXPR, ...)` inside the per-file loop
of `load_duct_runs()`, inside a broad `except Exception` block. The reporter
in #440 had a hidden U+00A0 non-breaking space in their filter expression
(easy to produce on macOS with Option+Space, or when copy-pasting from a
browser/document). The resulting `SyntaxError` was caught, misattributed
to each JSON file, and logged as:

```
Failed to load file <_io.TextIOWrapper name='.duct/logs/…_info.json'>: invalid non-printable character U+00A0 (<string>, line 1)
```

— which sent the user hunting through their JSON logs for corruption that
was never there.

This PR centralises filter compilation so a bad expression fails **once,
up-front, with a clear message**, before any file is opened.

- New `compile_eval_filter()` helper compiles the expression once via
  `compile(..., '<eval-filter>', 'eval')`. On `SyntaxError` it raises
  `ValueError` naming the offending expression and explicitly hinting at
  U+00A0 / macOS Option+Space as a common cause.
- `ls()` calls it first thing, catches `ValueError`, logs it via
  `lgr.error`, and returns exit code 2 — no traceback, no per-file noise.
- `load_duct_runs()` now accepts either a string (which it compiles) or a
  pre-compiled `CodeType`, and reuses it in the per-file `eval()` loop —
  also avoids re-parsing the expression once per file.

After the fix, the reporter's command produces:

```
[ERROR   ] con_duct.ls: Invalid --eval-filter expression '"fmriprep" in command and\xa0exit_code == 1': invalid non-printable character U+00A0 (<eval-filter>, line 1). Check for hidden non-printable characters (e.g. U+00A0 non-breaking space produced by macOS Option+Space or copy-paste from a browser/document).
```

and exits with code 2.

## Test plan

- [x] `tox -e py3 -- test/test_ls.py` — 29 passed (23 pre-existing + 6 new)
- [x] Full suite: `tox -- test/` — 397 passed
- [x] `tox -e lint` — clean
- [x] `tox -e typing` — clean
- [x] Manual repro of the #440 command (with a real U+00A0 injected via
      `printf '%b'`) now prints the single ERROR above and exits 2.

New tests added to `test/test_ls.py`:

- `test_compile_eval_filter_none_returns_none`
- `test_compile_eval_filter_valid`
- `test_compile_eval_filter_rejects_nbsp` (regression test for #440)
- `test_compile_eval_filter_rejects_syntax_error`
- `test_load_duct_runs_fails_fast_on_bad_filter` — verifies no file is
  even opened when the filter is invalid, and no per-file "Failed to load
  file" warning is emitted.
- `test_ls_exits_cleanly_on_bad_filter` — verifies exit code 2 and a
  user-facing ERROR log line mentioning `U+00A0`.
