### PR TITLE
Add --sort-by option to ls command for flexible result ordering

### DIFF
--- a/src/con_duct/cli.py
+++ b/src/con_duct/cli.py
@@ -466,6 +466,13 @@ def _create_ls_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="List entries in reverse order (most recent first).",
     )
+    parser.add_argument(
+        "--sort-by",
+        nargs="+",
+        metavar="FIELD",
+        choices=LS_FIELD_CHOICES,
+        help=f"Sort results by one or more fields. Available choices: {', '.join(sorted(LS_FIELD_CHOICES))}.",
+    )
     return parser
 
 

--- a/src/con_duct/cli.py
+++ b/src/con_duct/cli.py
@@ -464,14 +464,14 @@ def _create_ls_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--reverse",
         action="store_true",
-        help="List entries in reverse order (most recent first).",
+        help="List entries in reverse order.",
     )
     parser.add_argument(
         "--sort-by",
         nargs="+",
         metavar="FIELD",
         choices=LS_FIELD_CHOICES,
-        help=f"Sort results by one or more fields. Available choices: {', '.join(sorted(LS_FIELD_CHOICES))}.",
+        help="Sort results by one or more fields. See --fields for available choices.",
     )
     return parser
 

--- a/src/con_duct/cli.py
+++ b/src/con_duct/cli.py
@@ -471,7 +471,9 @@ def _create_ls_parser() -> argparse.ArgumentParser:
         nargs="+",
         metavar="FIELD",
         choices=LS_FIELD_CHOICES,
-        help="Sort results by one or more fields. See --fields for available choices.",
+        help="Sort results by one or more fields (later fields break ties of the "
+        "earlier ones). Runs missing a field are listed last. See --fields for "
+        "available choices. Combine with --reverse for descending order.",
     )
     return parser
 

--- a/src/con_duct/cli.py
+++ b/src/con_duct/cli.py
@@ -586,6 +586,9 @@ def main(argv: Optional[List[str]] = None) -> None:
     _replay_early_logs(env_log_buffer)
     try:
         returncode = execute(args)
+        # Flush here so a pipe closed after the last write surfaces now, not
+        # during interpreter shutdown, where it would be past this except.
+        sys.stdout.flush()
     except BrokenPipeError:
         _exit_broken_pipe()
     sys.exit(returncode)

--- a/src/con_duct/cli.py
+++ b/src/con_duct/cli.py
@@ -472,8 +472,9 @@ def _create_ls_parser() -> argparse.ArgumentParser:
         metavar="FIELD",
         choices=LS_FIELD_CHOICES,
         help="Sort results by one or more fields (later fields break ties of the "
-        "earlier ones). Runs missing a field are listed last. See --fields for "
-        "available choices. Combine with --reverse for descending order.",
+        "earlier ones, and the prefix breaks the rest). Runs with no value for a "
+        "field are listed last, or first when combined with --reverse for "
+        "descending order. See --fields for available choices.",
     )
     return parser
 

--- a/src/con_duct/cli.py
+++ b/src/con_duct/cli.py
@@ -108,6 +108,9 @@ def _replay_early_logs(log_buffer: List[tuple[str, str]]) -> None:
 
 lgr = logging.getLogger("con-duct")
 
+# What a shell reports for a command killed by SIGPIPE (128 + 13)
+EXIT_BROKEN_PIPE = 141
+
 # Format default config paths as a bulleted list for help text
 _config_paths_list = "\n".join(f"    - {path}" for path in DEFAULT_CONFIG_PATHS_LIST)
 
@@ -498,6 +501,23 @@ def execute(args: argparse.Namespace) -> int:
     return result
 
 
+def _exit_broken_pipe() -> None:
+    """Exit quietly after the reader of our stdout went away.
+
+    Happens routinely for e.g. `con-duct ls | head`. Python flushes stdout
+    while shutting down, which would raise a second BrokenPipeError and print
+    a traceback, so point the file descriptor at /dev/null first -- as the
+    Python docs on SIGPIPE recommend.
+    """
+    try:
+        devnull = os.open(os.devnull, os.O_WRONLY)
+        os.dup2(devnull, sys.stdout.fileno())
+    except (OSError, ValueError):
+        # stdout is not a real file descriptor (e.g. captured in tests)
+        pass
+    sys.exit(EXIT_BROKEN_PIPE)
+
+
 def duct_entrypoint() -> None:
     """Entry point for the 'duct' command - delegates to 'con-duct run'."""
     os.execvp("con-duct", ["con-duct", "run"] + sys.argv[1:])
@@ -564,7 +584,11 @@ def main(argv: Optional[List[str]] = None) -> None:
 
     setup_logging(args)
     _replay_early_logs(env_log_buffer)
-    sys.exit(execute(args))
+    try:
+        returncode = execute(args)
+    except BrokenPipeError:
+        _exit_broken_pipe()
+    sys.exit(returncode)
 
 
 # To allow users or devs to invoke the `cli.py` directly

--- a/src/con_duct/ls.py
+++ b/src/con_duct/ls.py
@@ -232,15 +232,16 @@ def ls(args: argparse.Namespace) -> int:
     info_files = [path for path in args.paths if is_info_file(path)]
     run_data_raw = load_duct_runs(info_files, args.eval_filter)
 
-    sort_by = getattr(args, "sort_by", None)
-    if sort_by:
-        flat_data = [_flatten_dict(d) for d in run_data_raw]
+    if sort_by := getattr(args, "sort_by", None):
         run_data_raw = [
             item
             for _, item in sorted(
-                zip(flat_data, run_data_raw),
+                zip(map(_flatten_dict, run_data_raw), run_data_raw),
                 key=lambda x: tuple(
-                    (x[0].get(k) is None, x[0].get(k) if x[0].get(k) is not None else "")
+                    (
+                        x[0].get(k) is None,
+                        x[0].get(k) if x[0].get(k) is not None else "",
+                    )
                     for k in sort_by
                 ),
             )

--- a/src/con_duct/ls.py
+++ b/src/con_duct/ls.py
@@ -231,6 +231,21 @@ def ls(args: argparse.Namespace) -> int:
     )
     info_files = [path for path in args.paths if is_info_file(path)]
     run_data_raw = load_duct_runs(info_files, args.eval_filter)
+
+    sort_by = getattr(args, "sort_by", None)
+    if sort_by:
+        flat_data = [_flatten_dict(d) for d in run_data_raw]
+        run_data_raw = [
+            item
+            for _, item in sorted(
+                zip(flat_data, run_data_raw),
+                key=lambda x: tuple(
+                    (x[0].get(k) is None, x[0].get(k) if x[0].get(k) is not None else "")
+                    for k in sort_by
+                ),
+            )
+        ]
+
     output_rows = process_run_data(run_data_raw, args.fields, formatter)
 
     if args.reverse:

--- a/src/con_duct/ls.py
+++ b/src/con_duct/ls.py
@@ -149,6 +149,19 @@ def _flatten_dict(d: Dict[str, Any]) -> Dict[str, Any]:
     return dict(items)
 
 
+def _make_sort_value(v: Any) -> Any:
+    """Convert a field value to a sortable representation.
+
+    Lists and dicts are serialised to a JSON string to give a stable
+    deterministic ordering without raising TypeError.
+    """
+    if v is None:
+        return ""
+    if isinstance(v, (list, dict)):
+        return json.dumps(v, sort_keys=True)
+    return v
+
+
 def _restrict_row(field_list: List[str], row: Dict[str, Any]) -> OrderedDict[str, Any]:
     restricted: OrderedDict[str, Any] = OrderedDict()
     # prefix is the "primary key", its the only field guaranteed to be unique.
@@ -240,7 +253,7 @@ def ls(args: argparse.Namespace) -> int:
                 key=lambda x: tuple(
                     (
                         x[0].get(k) is None,
-                        x[0].get(k) if x[0].get(k) is not None else "",
+                        _make_sort_value(x[0].get(k)),
                     )
                     for k in sort_by
                 ),

--- a/src/con_duct/ls.py
+++ b/src/con_duct/ls.py
@@ -178,17 +178,92 @@ def _flatten_dict(d: Dict[str, Any]) -> Dict[str, Any]:
     return dict(items)
 
 
-def _make_sort_value(v: Any) -> Any:
-    """Convert a field value to a sortable representation.
+# Ranks keep values of different types in separate ordering buckets so that
+# they are never compared to each other (which would raise a TypeError).
+_SORT_RANK_NUMBER = 0
+_SORT_RANK_TEXT = 1
+_SORT_RANK_OTHER = 2
+_SORT_RANK_MISSING = 3  # missing/None always sorts last
 
-    Lists and dicts are serialised to a JSON string to give a stable
-    deterministic ordering without raising TypeError.
+
+def _natural_chunks(text: str) -> tuple[tuple[int, int, str], ...]:
+    """Split `text` into chunks which sort "naturally".
+
+    Digit runs are compared as numbers and everything else as text, so
+    e.g. version 0.9.0 sorts before 0.10.0 and run2_ before run10_.
+    Every chunk has the same (kind, number, text) shape so that a digit
+    chunk is never compared against a text chunk.
+
+    Args:
+        text: String to split.
+
+    Returns:
+        Tuple of comparable (kind, number, text) chunks.
     """
-    if v is None:
-        return ""
-    if isinstance(v, (list, dict)):
-        return json.dumps(v, sort_keys=True)
-    return v
+    # re.split with a capturing group alternates text, digits, text, ...
+    return tuple(
+        (0, int(part), "") if i % 2 else (1, 0, part)
+        for i, part in enumerate(re.split(r"(\d+)", text))
+        if part
+    )
+
+
+def _sort_key(value: Any) -> tuple[int, Any]:
+    """Convert a field value into a total-ordering sort key.
+
+    `ls` fields are whatever the info.json files happen to contain, so a
+    single field can hold numbers in one run, strings in another, a list
+    (e.g. `gpu`) in a third and be missing from a fourth. Ranking by type
+    keeps such values comparable instead of raising a TypeError.
+
+    Args:
+        value: Raw (unformatted) field value.
+
+    Returns:
+        (rank, comparable value) pair; missing values rank last.
+    """
+    if value is None:
+        return (_SORT_RANK_MISSING, ())
+    if isinstance(value, (bool, int, float)):
+        return (_SORT_RANK_NUMBER, value)
+    if isinstance(value, str):
+        return (_SORT_RANK_TEXT, _natural_chunks(value))
+    # Lists/dicts and anything else exotic: compare a deterministic
+    # serialization rather than blowing up.
+    return (
+        _SORT_RANK_OTHER,
+        _natural_chunks(json.dumps(value, sort_keys=True, default=str)),
+    )
+
+
+def _sort_run_data(
+    run_data_list: List[Dict[str, Any]], sort_by: List[str]
+) -> List[Dict[str, Any]]:
+    """Sort raw (unformatted) run records by the given fields.
+
+    Sorting happens before fields are restricted to `--fields` and before
+    values are formatted, so any field may be used as a sort key -- also
+    one which is not displayed -- and numeric fields sort numerically
+    rather than as their rendered strings.
+
+    Args:
+        run_data_list: Raw run records as loaded from info.json files.
+        sort_by: Field names to sort by, in order of precedence.
+
+    Returns:
+        New list of the same records in sorted order.
+    """
+    # Flatten once per record rather than once per comparison.
+    decorated = [(_flatten_dict(run), run) for run in run_data_list]
+    for field in sort_by:
+        if decorated and all(flat.get(field) is None for flat, _ in decorated):
+            lgr.warning(
+                "No run provides --sort-by field %r, it does not affect the "
+                "ordering.",
+                field,
+            )
+    decorated.sort(key=lambda pair: tuple(_sort_key(pair[0].get(f)) for f in sort_by))
+    return [run for _, run in decorated]
 
 
 def _restrict_row(field_list: List[str], row: Dict[str, Any]) -> OrderedDict[str, Any]:
@@ -283,20 +358,8 @@ def ls(args: argparse.Namespace) -> int:
     info_files = [path for path in args.paths if is_info_file(path)]
     run_data_raw = load_duct_runs(info_files, compiled_filter)
 
-    if sort_by := getattr(args, "sort_by", None):
-        run_data_raw = [
-            item
-            for _, item in sorted(
-                zip(map(_flatten_dict, run_data_raw), run_data_raw),
-                key=lambda x: tuple(
-                    (
-                        x[0].get(k) is None,
-                        _make_sort_value(x[0].get(k)),
-                    )
-                    for k in sort_by
-                ),
-            )
-        ]
+    if args.sort_by:
+        run_data_raw = _sort_run_data(run_data_raw, args.sort_by)
 
     output_rows = process_run_data(run_data_raw, args.fields, formatter)
 

--- a/src/con_duct/ls.py
+++ b/src/con_duct/ls.py
@@ -211,123 +211,64 @@ def _flatten_dict(d: Dict[str, Any]) -> Dict[str, Any]:
     return dict(items)
 
 
-# Ranks keep values of different types in separate ordering buckets so that
-# they are never compared to each other (which would raise a TypeError).
-_SORT_RANK_NUMBER = 0
-_SORT_RANK_TEXT = 1
-_SORT_RANK_OTHER = 2
-_SORT_RANK_MISSING = 3  # valueless always sorts last
-
-# Longest digit run still compared as a number; comfortably wider than any
-# real value and within int()'s parsing limit.
+# Digit runs longer than this are compared as text: they are not meaningful
+# numbers, and int() refuses to parse more than sys.get_int_max_str_digits().
 _MAX_SORT_DIGITS = 18
+_RANK_MISSING = 3  # valueless always sorts last (before numbers, text, other)
 
 
 def _natural_chunks(text: str) -> tuple[tuple[int, int, str], ...]:
-    """Split `text` into chunks which sort "naturally".
+    """Split text into chunks which sort naturally: 0.9.0 < 0.10.0, run2 < run10.
 
-    Digit runs are compared as numbers and everything else as text, so
-    e.g. version 0.9.0 sorts before 0.10.0 and run2_ before run10_.
-    Every chunk has the same (kind, number, text) shape so that a digit
-    chunk is never compared against a text chunk.
-
-    Args:
-        text: String to split.
-
-    Returns:
-        Tuple of comparable (kind, number, text) chunks.
+    Digit runs are compared as numbers and everything else as text.  Every
+    chunk has the same (kind, number, text) shape so that chunks never
+    cross-compare (which would raise TypeError).
     """
-    chunks: List[tuple[int, int, str]] = []
     # re.split with a capturing group alternates text, digits, text, ...
-    for i, part in enumerate(re.split(r"(\d+)", text)):
-        if not part:
-            continue
-        # Free-form fields (message, command, ...) can hold a digit run far
-        # too long to be a meaningful number -- and int() refuses to parse
-        # more than sys.get_int_max_str_digits() of them anyway -- so those
-        # are compared as text rather than raising ValueError.
-        if i % 2 and len(part) <= _MAX_SORT_DIGITS:
-            chunks.append((0, int(part), ""))
-        else:
-            chunks.append((1, 0, part))
-    return tuple(chunks)
-
-
-def _has_value(value: Any) -> bool:
-    """Whether a field value carries anything to order runs by.
-
-    `ensure_compliant_schema()` backfills fields added in later schema
-    versions with "", so an empty string means "not recorded" just as much
-    as a missing key or a JSON null does.
-    """
-    return value is not None and value != ""
+    return tuple(
+        (0, int(part), "") if i % 2 and len(part) <= _MAX_SORT_DIGITS else (1, 0, part)
+        for i, part in enumerate(re.split(r"(\d+)", text))
+        if part
+    )
 
 
 def _sort_key(value: Any) -> tuple[int, Any]:
-    """Convert a field value into a total-ordering sort key.
+    """Total-ordering key for a raw field value.
 
-    `ls` fields are whatever the info.json files happen to contain, so a
-    single field can hold numbers in one run, strings in another, a list
-    (e.g. `gpu`) in a third and be missing from a fourth. Ranking by type
-    keeps such values comparable instead of raising a TypeError.
-
-    Args:
-        value: Raw (unformatted) field value.
-
-    Returns:
-        (rank, comparable value) pair; valueless fields rank last.
+    A field can hold a number in one run, a string in another, a list (e.g.
+    `gpu`) in a third and be missing from a fourth, so values are ranked by
+    type and only compared within a rank.  None, "" (what
+    `ensure_compliant_schema()` backfills) and NaN all count as no value.
     """
-    if not _has_value(value):
-        return (_SORT_RANK_MISSING, ())
+    if value is None or value == "" or value != value:
+        return (_RANK_MISSING, ())
     if isinstance(value, (bool, int, float)):
-        # NaN compares false against everything, which would make the
-        # ordering depend on the input order -- treat it as no value.
-        if value != value:
-            return (_SORT_RANK_MISSING, ())
-        return (_SORT_RANK_NUMBER, value)
+        return (0, value)
     if isinstance(value, str):
-        return (_SORT_RANK_TEXT, _natural_chunks(value))
-    # Lists/dicts and anything else exotic: compare a deterministic
-    # serialization rather than blowing up.
-    return (
-        _SORT_RANK_OTHER,
-        _natural_chunks(json.dumps(value, sort_keys=True, default=str)),
-    )
+        return (1, _natural_chunks(value))
+    return (2, _natural_chunks(json.dumps(value, sort_keys=True, default=str)))
 
 
 def _sort_run_data(
     run_data_list: List[Dict[str, Any]], sort_by: List[str]
 ) -> List[Dict[str, Any]]:
-    """Sort raw (unformatted) run records by the given fields.
+    """Sort raw run records by `sort_by` fields; later fields break ties.
 
-    Sorting happens before fields are restricted to `--fields` and before
-    values are formatted, so any field may be used as a sort key -- also
-    one which is not displayed -- and numeric fields sort numerically
-    rather than as their rendered strings.  `prefix` breaks any remaining
-    tie, so the order is reproducible across runs.
-
-    Args:
-        run_data_list: Raw run records as loaded from info.json files.
-        sort_by: Field names to sort by, in order of precedence.
-
-    Returns:
-        New list of the same records in sorted order.
+    Runs on the raw records (before `--fields` restriction and formatting)
+    so any field can be a key and numbers sort numerically.  `prefix`, the
+    only unique field, breaks any remaining tie for a reproducible order.
     """
-    # Flatten once per record rather than once per comparison.
     decorated = [(_flatten_dict(run), run) for run in run_data_list]
     for field in sort_by:
-        # A field absent everywhere, null everywhere (e.g. "gpu" on a machine
-        # without a GPU) or backfilled with "" is equally a no-op for ordering
-        if decorated and not any(_has_value(flat.get(field)) for flat, _ in decorated):
+        if decorated and all(
+            _sort_key(flat.get(field))[0] == _RANK_MISSING for flat, _ in decorated
+        ):
             lgr.warning(
                 "No run has a value for --sort-by field %r, it does not affect "
                 "the ordering.",
                 field,
             )
-    # prefix is the only field guaranteed to be unique, so break remaining
-    # ties with it -- otherwise equally-keyed runs come out in the order the
-    # paths were given, which is arbitrary glob order when they were globbed.
-    fields = sort_by if "prefix" in sort_by else [*sort_by, "prefix"]
+    fields = [*sort_by, "prefix"]
     decorated.sort(key=lambda pair: tuple(_sort_key(pair[0].get(f)) for f in fields))
     return [run for _, run in decorated]
 

--- a/src/con_duct/ls.py
+++ b/src/con_duct/ls.py
@@ -216,7 +216,11 @@ def _flatten_dict(d: Dict[str, Any]) -> Dict[str, Any]:
 _SORT_RANK_NUMBER = 0
 _SORT_RANK_TEXT = 1
 _SORT_RANK_OTHER = 2
-_SORT_RANK_MISSING = 3  # missing/None always sorts last
+_SORT_RANK_MISSING = 3  # valueless always sorts last
+
+# Longest digit run still compared as a number; comfortably wider than any
+# real value and within int()'s parsing limit.
+_MAX_SORT_DIGITS = 18
 
 
 def _natural_chunks(text: str) -> tuple[tuple[int, int, str], ...]:
@@ -233,12 +237,30 @@ def _natural_chunks(text: str) -> tuple[tuple[int, int, str], ...]:
     Returns:
         Tuple of comparable (kind, number, text) chunks.
     """
+    chunks: List[tuple[int, int, str]] = []
     # re.split with a capturing group alternates text, digits, text, ...
-    return tuple(
-        (0, int(part), "") if i % 2 else (1, 0, part)
-        for i, part in enumerate(re.split(r"(\d+)", text))
-        if part
-    )
+    for i, part in enumerate(re.split(r"(\d+)", text)):
+        if not part:
+            continue
+        # Free-form fields (message, command, ...) can hold a digit run far
+        # too long to be a meaningful number -- and int() refuses to parse
+        # more than sys.get_int_max_str_digits() of them anyway -- so those
+        # are compared as text rather than raising ValueError.
+        if i % 2 and len(part) <= _MAX_SORT_DIGITS:
+            chunks.append((0, int(part), ""))
+        else:
+            chunks.append((1, 0, part))
+    return tuple(chunks)
+
+
+def _has_value(value: Any) -> bool:
+    """Whether a field value carries anything to order runs by.
+
+    `ensure_compliant_schema()` backfills fields added in later schema
+    versions with "", so an empty string means "not recorded" just as much
+    as a missing key or a JSON null does.
+    """
+    return value is not None and value != ""
 
 
 def _sort_key(value: Any) -> tuple[int, Any]:
@@ -253,11 +275,15 @@ def _sort_key(value: Any) -> tuple[int, Any]:
         value: Raw (unformatted) field value.
 
     Returns:
-        (rank, comparable value) pair; missing values rank last.
+        (rank, comparable value) pair; valueless fields rank last.
     """
-    if value is None:
+    if not _has_value(value):
         return (_SORT_RANK_MISSING, ())
     if isinstance(value, (bool, int, float)):
+        # NaN compares false against everything, which would make the
+        # ordering depend on the input order -- treat it as no value.
+        if value != value:
+            return (_SORT_RANK_MISSING, ())
         return (_SORT_RANK_NUMBER, value)
     if isinstance(value, str):
         return (_SORT_RANK_TEXT, _natural_chunks(value))
@@ -277,7 +303,8 @@ def _sort_run_data(
     Sorting happens before fields are restricted to `--fields` and before
     values are formatted, so any field may be used as a sort key -- also
     one which is not displayed -- and numeric fields sort numerically
-    rather than as their rendered strings.
+    rather than as their rendered strings.  `prefix` breaks any remaining
+    tie, so the order is reproducible across runs.
 
     Args:
         run_data_list: Raw run records as loaded from info.json files.
@@ -289,15 +316,19 @@ def _sort_run_data(
     # Flatten once per record rather than once per comparison.
     decorated = [(_flatten_dict(run), run) for run in run_data_list]
     for field in sort_by:
-        # A field which is absent everywhere and one which is null everywhere
-        # (e.g. "gpu" on a machine without a GPU) are both no-ops for ordering
-        if decorated and all(flat.get(field) is None for flat, _ in decorated):
+        # A field absent everywhere, null everywhere (e.g. "gpu" on a machine
+        # without a GPU) or backfilled with "" is equally a no-op for ordering
+        if decorated and not any(_has_value(flat.get(field)) for flat, _ in decorated):
             lgr.warning(
                 "No run has a value for --sort-by field %r, it does not affect "
                 "the ordering.",
                 field,
             )
-    decorated.sort(key=lambda pair: tuple(_sort_key(pair[0].get(f)) for f in sort_by))
+    # prefix is the only field guaranteed to be unique, so break remaining
+    # ties with it -- otherwise equally-keyed runs come out in the order the
+    # paths were given, which is arbitrary glob order when they were globbed.
+    fields = sort_by if "prefix" in sort_by else [*sort_by, "prefix"]
+    decorated.sort(key=lambda pair: tuple(_sort_key(pair[0].get(f)) for f in fields))
     return [run for _, run in decorated]
 
 

--- a/src/con_duct/ls.py
+++ b/src/con_duct/ls.py
@@ -289,10 +289,12 @@ def _sort_run_data(
     # Flatten once per record rather than once per comparison.
     decorated = [(_flatten_dict(run), run) for run in run_data_list]
     for field in sort_by:
+        # A field which is absent everywhere and one which is null everywhere
+        # (e.g. "gpu" on a machine without a GPU) are both no-ops for ordering
         if decorated and all(flat.get(field) is None for flat, _ in decorated):
             lgr.warning(
-                "No run provides --sort-by field %r, it does not affect the "
-                "ordering.",
+                "No run has a value for --sort-by field %r, it does not affect "
+                "the ordering.",
                 field,
             )
     decorated.sort(key=lambda pair: tuple(_sort_key(pair[0].get(f)) for f in sort_by))

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -236,6 +236,15 @@ def test_ls_sort_by_rejects_unknown_field(capsys: pytest.CaptureFixture) -> None
     assert "invalid choice" in capsys.readouterr().err
 
 
+def test_main_exits_with_the_subcommand_returncode() -> None:
+    """main() hands the subcommand's return code to sys.exit()."""
+    with patch("con_duct.cli.ls", return_value=3):
+        with pytest.raises(SystemExit) as excinfo:
+            cli.main(["ls", "/no/such/file_info.json"])
+
+    assert excinfo.value.code == 3
+
+
 def test_broken_pipe_exits_without_traceback() -> None:
     """`con-duct ls | head` must not end in a BrokenPipeError traceback."""
 

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -9,7 +9,7 @@ from unittest import mock
 from unittest.mock import MagicMock, patch
 import pytest
 from con_duct import cli
-from con_duct.cli import _create_run_parser
+from con_duct.cli import _create_ls_parser, _create_run_parser
 
 SYSTEM = platform.system()
 
@@ -214,3 +214,23 @@ def test_message_env_variable() -> None:
         parser = _create_run_parser()
         args = parser.parse_args(["-m", "cli message", "echo", "hello"])
         assert args.message == "cli message"
+
+
+def test_ls_sort_by_parsing() -> None:
+    """--sort-by accepts one or more known fields and defaults to None."""
+    parser = _create_ls_parser()
+
+    assert parser.parse_args([]).sort_by is None
+    assert parser.parse_args(["--sort-by", "prefix"]).sort_by == ["prefix"]
+    assert parser.parse_args(["--sort-by", "command", "prefix"]).sort_by == [
+        "command",
+        "prefix",
+    ]
+
+
+def test_ls_sort_by_rejects_unknown_field(capsys: pytest.CaptureFixture) -> None:
+    parser = _create_ls_parser()
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--sort-by", "not_a_field"])
+    assert "invalid choice" in capsys.readouterr().err

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -9,7 +9,7 @@ from unittest import mock
 from unittest.mock import MagicMock, patch
 import pytest
 from con_duct import cli
-from con_duct.cli import _create_ls_parser, _create_run_parser
+from con_duct.cli import EXIT_BROKEN_PIPE, _create_ls_parser, _create_run_parser
 
 SYSTEM = platform.system()
 
@@ -234,3 +234,32 @@ def test_ls_sort_by_rejects_unknown_field(capsys: pytest.CaptureFixture) -> None
     with pytest.raises(SystemExit):
         parser.parse_args(["--sort-by", "not_a_field"])
     assert "invalid choice" in capsys.readouterr().err
+
+
+def test_broken_pipe_exits_without_traceback() -> None:
+    """`con-duct ls | head` must not end in a BrokenPipeError traceback."""
+
+    def raise_broken_pipe(_args: Any) -> int:
+        raise BrokenPipeError(32, "Broken pipe")
+
+    argv = ["ls", "/no/such/file_info.json"]
+    # do not really point our stdout at /dev/null -- pytest is reading it
+    with patch("con_duct.cli.os.dup2") as mock_dup2:
+        with patch("con_duct.cli.ls", raise_broken_pipe):
+            with pytest.raises(SystemExit) as excinfo:
+                cli.main(argv)
+
+    assert excinfo.value.code == EXIT_BROKEN_PIPE
+    mock_dup2.assert_called_once()
+
+
+def test_broken_pipe_survives_a_stdout_without_fileno() -> None:
+    """Redirecting stdout to /dev/null is best effort, not a second failure."""
+    fake_stdout = MagicMock()
+    fake_stdout.fileno.side_effect = ValueError("no fileno")
+
+    with patch("con_duct.cli.sys.stdout", fake_stdout):
+        with pytest.raises(SystemExit) as excinfo:
+            cli._exit_broken_pipe()
+
+    assert excinfo.value.code == EXIT_BROKEN_PIPE

--- a/test/test_ls.py
+++ b/test/test_ls.py
@@ -12,6 +12,7 @@ import pytest
 from con_duct._constants import __schema_version__
 from con_duct._formatter import SummaryFormatter
 from con_duct.ls import (
+    LS_FIELD_CHOICES,
     MINIMUM_SCHEMA_VERSION,
     _flatten_dict,
     _restrict_row,
@@ -473,3 +474,73 @@ def test_ls_sort_by_non_displayed_field(tmp_path: Any) -> None:
     assert "run_a_" in prefixes[0]
     assert "run_b_" in prefixes[1]
     assert "run_c_" in prefixes[2]
+
+
+@pytest.mark.parametrize("sort_field", LS_FIELD_CHOICES)
+def test_ls_sort_by_each_field(sort_field: str, tmp_path: Any) -> None:
+    """Sorting by every LS_FIELD_CHOICES field must not crash and must produce sorted output."""
+    # Choose 3 values for the sort field, assigned to run1/run2/run3 in the order listed
+    # (val1 to run1, val2 to run2, val3 to run3).  After sorting, the expected output
+    # order must be run2, run1, run3 (smallest to largest).
+    if sort_field == "prefix":
+        # prefix is derived from the file path by load_duct_runs, not from JSON content.
+        filenames = ["run_b_info.json", "run_a_info.json", "run_c_info.json"]
+        base = {"schema_version": __schema_version__, "execution_summary": {}}
+        for fn in filenames:
+            (tmp_path / fn).write_text(json.dumps(base))
+        paths = [str(tmp_path / fn) for fn in filenames]
+        # sorted prefix order: ...run_a_ < ...run_b_ < ...run_c_
+        expected_fragments = ["run_a_", "run_b_", "run_c_"]
+    else:
+        # Assign sort values so run2 < run1 < run3.
+        if sort_field == "schema_version":
+            # Must be valid version strings >= MINIMUM_SCHEMA_VERSION.
+            val1, val2, val3 = "0.2.1", "0.2.0", "0.2.2"
+        elif sort_field == "gpu":
+            # gpu is a list[dict]; _make_sort_value serialises to JSON string.
+            val1 = [{"name": "gpu_b"}]
+            val2 = [{"name": "gpu_a"}]
+            val3 = [{"name": "gpu_c"}]
+        else:
+            val1, val2, val3 = "sort_b", "sort_a", "sort_c"
+
+        def build_run(val: Any) -> Dict[str, Any]:
+            # Use the current schema version so ensure_compliant_schema returns early
+            # and does not overwrite any fields we are setting for the test.
+            data: Dict[str, Any] = {
+                "schema_version": __schema_version__,
+                "execution_summary": {},
+            }
+            if sort_field == "schema_version":
+                data["schema_version"] = val
+            else:
+                # Place at top level; _flatten_dict will expose it for sorting.
+                data[sort_field] = val
+            return data
+
+        filenames = [f"run{i}_info.json" for i in range(1, 4)]
+        for fn, val in zip(filenames, [val1, val2, val3]):
+            (tmp_path / fn).write_text(json.dumps(build_run(val)))
+        paths = [str(tmp_path / fn) for fn in filenames]
+        # sorted: val2(run2) < val1(run1) < val3(run3)
+        expected_fragments = ["run2_", "run1_", "run3_"]
+
+    args = argparse.Namespace(
+        paths=paths,
+        colors=False,
+        fields=["prefix"],
+        eval_filter=None,
+        format="json",
+        func=ls,
+        reverse=False,
+        sort_by=[sort_field],
+    )
+    buf = StringIO()
+    with contextlib.redirect_stdout(buf):
+        assert ls(args) == 0
+    prefixes = [row["prefix"] for row in json.loads(buf.getvalue().strip())]
+    for i, fragment in enumerate(expected_fragments):
+        assert fragment in prefixes[i], (
+            f"sort_by={sort_field!r}: position {i} expected '{fragment}' in prefix,"
+            f" got '{prefixes[i]}'"
+        )

--- a/test/test_ls.py
+++ b/test/test_ls.py
@@ -429,3 +429,47 @@ def test_ls_sort_by(reverse: bool, tmp_path: Any) -> None:
         assert ls(args) == 0
     prefixes = [row["prefix"] for row in json.loads(buf.getvalue().strip())]
     assert prefixes == sorted(prefixes, reverse=reverse)
+
+
+def test_ls_sort_by_non_displayed_field(tmp_path: Any) -> None:
+    """Test --sort-by works for fields not included in --fields (not displayed)."""
+    # Three runs with commands in non-alphabetical order; paths also in non-alphabetical
+    # order so glob/filesystem order cannot accidentally pass the test.
+    entries = [
+        ("run_b_info.json", "cmd_b"),
+        ("run_a_info.json", "cmd_a"),
+        ("run_c_info.json", "cmd_c"),
+    ]
+    for filename, command in entries:
+        (tmp_path / filename).write_text(
+            json.dumps(
+                {
+                    "schema_version": MINIMUM_SCHEMA_VERSION,
+                    "execution_summary": {},
+                    "command": command,
+                }
+            )
+        )
+
+    # paths deliberately in creation order (b, a, c) — not sorted by command
+    paths = [str(tmp_path / filename) for filename, _ in entries]
+    args = argparse.Namespace(
+        paths=paths,
+        colors=False,
+        fields=["prefix"],  # "command" is intentionally NOT in displayed fields
+        eval_filter=None,
+        format="json",
+        func=ls,
+        reverse=False,
+        sort_by=["command"],
+    )
+    buf = StringIO()
+    with contextlib.redirect_stdout(buf):
+        assert ls(args) == 0
+    rows = json.loads(buf.getvalue().strip())
+    # Output order should match sorted command order: cmd_a, cmd_b, cmd_c
+    # which corresponds to run_a, run_b, run_c prefixes
+    prefixes = [row["prefix"] for row in rows]
+    assert "run_a_" in prefixes[0]
+    assert "run_b_" in prefixes[1]
+    assert "run_c_" in prefixes[2]

--- a/test/test_ls.py
+++ b/test/test_ls.py
@@ -393,40 +393,39 @@ class TestLS(unittest.TestCase):
 
         assert prefixes_reversed == list(reversed(prefixes_normal))
 
-    def test_ls_sort_by(self) -> None:
-        """Test --sort-by flag sorts entries by the specified field."""
-        paths = ["file1_info.json", "file2_info.json"]
 
-        args = argparse.Namespace(
-            paths=[os.path.join(self.temp_dir.name, path) for path in paths],
-            colors=False,
-            fields=["prefix", "schema_version"],
-            eval_filter=None,
-            format="json",
-            func=ls,
-            reverse=False,
-            sort_by=["prefix"],
-        )
-        result = self._run_ls(paths, "json", args)
-        parsed = json.loads(result)
-        prefixes = [row["prefix"] for row in parsed]
-        assert prefixes == sorted(prefixes)
+@pytest.mark.parametrize("reverse", [False, True])
+def test_ls_sort_by(reverse: bool, tmp_path: Any) -> None:
+    """Test --sort-by flag sorts entries by the specified field, with optional reverse."""
+    files = {
+        "file1_info.json": {
+            "schema_version": MINIMUM_SCHEMA_VERSION,
+            "execution_summary": {},
+            "prefix": "test1",
+        },
+        "file2_info.json": {
+            "schema_version": MINIMUM_SCHEMA_VERSION,
+            "execution_summary": {},
+            "prefix": "test2",
+        },
+    }
+    for filename, content in files.items():
+        path = tmp_path / filename
+        path.write_text(json.dumps(content))
 
-    def test_ls_sort_by_reverse(self) -> None:
-        """Test --sort-by combined with --reverse gives descending order."""
-        paths = ["file1_info.json", "file2_info.json"]
-
-        args = argparse.Namespace(
-            paths=[os.path.join(self.temp_dir.name, path) for path in paths],
-            colors=False,
-            fields=["prefix", "schema_version"],
-            eval_filter=None,
-            format="json",
-            func=ls,
-            reverse=True,
-            sort_by=["prefix"],
-        )
-        result = self._run_ls(paths, "json", args)
-        parsed = json.loads(result)
-        prefixes = [row["prefix"] for row in parsed]
-        assert prefixes == sorted(prefixes, reverse=True)
+    paths = [str(tmp_path / f) for f in files]
+    args = argparse.Namespace(
+        paths=paths,
+        colors=False,
+        fields=["prefix", "schema_version"],
+        eval_filter=None,
+        format="json",
+        func=ls,
+        reverse=reverse,
+        sort_by=["prefix"],
+    )
+    buf = StringIO()
+    with contextlib.redirect_stdout(buf):
+        assert ls(args) == 0
+    prefixes = [row["prefix"] for row in json.loads(buf.getvalue().strip())]
+    assert prefixes == sorted(prefixes, reverse=reverse)

--- a/test/test_ls.py
+++ b/test/test_ls.py
@@ -223,6 +223,7 @@ class TestLS(unittest.TestCase):
                 format=fmt,
                 func=ls,
                 reverse=False,
+                sort_by=None,
             )
         buf = StringIO()
         with contextlib.redirect_stdout(buf):
@@ -255,6 +256,7 @@ class TestLS(unittest.TestCase):
             format="summaries",
             func=ls,
             reverse=False,
+            sort_by=None,
         )
         result = self._run_ls(paths, "summaries", args)
 
@@ -383,9 +385,48 @@ class TestLS(unittest.TestCase):
             format="json",
             func=ls,
             reverse=True,
+            sort_by=None,
         )
         result_reversed = self._run_ls(paths, "json", args)
         parsed_reversed = json.loads(result_reversed)
         prefixes_reversed = [row["prefix"] for row in parsed_reversed]
 
         assert prefixes_reversed == list(reversed(prefixes_normal))
+
+    def test_ls_sort_by(self) -> None:
+        """Test --sort-by flag sorts entries by the specified field."""
+        paths = ["file1_info.json", "file2_info.json"]
+
+        args = argparse.Namespace(
+            paths=[os.path.join(self.temp_dir.name, path) for path in paths],
+            colors=False,
+            fields=["prefix", "schema_version"],
+            eval_filter=None,
+            format="json",
+            func=ls,
+            reverse=False,
+            sort_by=["prefix"],
+        )
+        result = self._run_ls(paths, "json", args)
+        parsed = json.loads(result)
+        prefixes = [row["prefix"] for row in parsed]
+        assert prefixes == sorted(prefixes)
+
+    def test_ls_sort_by_reverse(self) -> None:
+        """Test --sort-by combined with --reverse gives descending order."""
+        paths = ["file1_info.json", "file2_info.json"]
+
+        args = argparse.Namespace(
+            paths=[os.path.join(self.temp_dir.name, path) for path in paths],
+            colors=False,
+            fields=["prefix", "schema_version"],
+            eval_filter=None,
+            format="json",
+            func=ls,
+            reverse=True,
+            sort_by=["prefix"],
+        )
+        result = self._run_ls(paths, "json", args)
+        parsed = json.loads(result)
+        prefixes = [row["prefix"] for row in parsed]
+        assert prefixes == sorted(prefixes, reverse=True)

--- a/test/test_ls.py
+++ b/test/test_ls.py
@@ -14,8 +14,11 @@ from con_duct._formatter import SummaryFormatter
 from con_duct.ls import (
     LS_FIELD_CHOICES,
     MINIMUM_SCHEMA_VERSION,
+    VALUE_TRANSFORMATION_MAP,
     _flatten_dict,
+    _natural_chunks,
     _restrict_row,
+    _sort_key,
     compile_eval_filter,
     ensure_compliant_schema,
     load_duct_runs,
@@ -208,6 +211,7 @@ def test_ls_exits_cleanly_on_bad_filter(
         format="summaries",
         func=ls,
         reverse=False,
+        sort_by=None,
     )
     with caplog.at_level(logging.ERROR):
         with patch("builtins.open") as mock_open_fn:
@@ -448,152 +452,244 @@ class TestLS(unittest.TestCase):
         assert prefixes_reversed == list(reversed(prefixes_normal))
 
 
-@pytest.mark.parametrize("reverse", [False, True])
-def test_ls_sort_by(reverse: bool, tmp_path: Any) -> None:
-    """Test --sort-by flag sorts entries by the specified field, with optional reverse."""
-    files = {
-        "file1_info.json": {
-            "schema_version": MINIMUM_SCHEMA_VERSION,
-            "execution_summary": {},
-            "prefix": "test1",
-        },
-        "file2_info.json": {
-            "schema_version": MINIMUM_SCHEMA_VERSION,
-            "execution_summary": {},
-            "prefix": "test2",
-        },
-    }
-    for filename, content in files.items():
-        path = tmp_path / filename
-        path.write_text(json.dumps(content))
+def _write_run(path: Any, **fields: Any) -> str:
+    """Write a minimal info.json containing `fields` and return its path.
 
-    paths = [str(tmp_path / f) for f in files]
+    Args:
+        path: Destination `*_info.json` path.
+        fields: Extra top level fields to store in the record.  The current
+            schema version is used by default so that
+            `ensure_compliant_schema` does not overwrite them.
+
+    Returns:
+        The path written, as a string.
+    """
+    record: Dict[str, Any] = {
+        "schema_version": __schema_version__,
+        "execution_summary": {},
+    }
+    record.update(fields)
+    path.write_text(json.dumps(record))
+    return str(path)
+
+
+def _ls_prefixes(
+    paths: list[str],
+    sort_by: Optional[list[str]] = None,
+    reverse: bool = False,
+    fields: Optional[list[str]] = None,
+) -> list[str]:
+    """Run `ls` in json format and return the prefixes in output order."""
     args = argparse.Namespace(
         paths=paths,
         colors=False,
-        fields=["prefix", "schema_version"],
+        fields=fields if fields is not None else ["prefix"],
         eval_filter=None,
         format="json",
         func=ls,
         reverse=reverse,
-        sort_by=["prefix"],
+        sort_by=sort_by,
     )
     buf = StringIO()
     with contextlib.redirect_stdout(buf):
         assert ls(args) == 0
-    prefixes = [row["prefix"] for row in json.loads(buf.getvalue().strip())]
-    assert prefixes == sorted(prefixes, reverse=reverse)
+    return [row["prefix"] for row in json.loads(buf.getvalue().strip())]
+
+
+def _basenames(prefixes: list[str]) -> list[str]:
+    """Reduce full prefixes to their `runX_` basenames for easy comparison."""
+    return [os.path.basename(prefix) for prefix in prefixes]
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+def test_ls_sort_by(reverse: bool, tmp_path: Any) -> None:
+    """--sort-by orders entries by the given field; --reverse flips that order."""
+    # Deliberately created (and passed) in non sorted order so that the test
+    # cannot pass just because the paths happen to be listed sorted already.
+    paths = [
+        _write_run(tmp_path / name)
+        for name in ("run_b_info.json", "run_c_info.json", "run_a_info.json")
+    ]
+    expected = ["run_a_", "run_b_", "run_c_"]
+    if reverse:
+        expected = list(reversed(expected))
+
+    assert _basenames(_ls_prefixes(paths, ["prefix"], reverse=reverse)) == expected
+
+
+def test_ls_sort_by_none_preserves_input_order(tmp_path: Any) -> None:
+    """Without --sort-by the order of the given paths is preserved."""
+    paths = [
+        _write_run(tmp_path / name)
+        for name in ("run_b_info.json", "run_c_info.json", "run_a_info.json")
+    ]
+
+    assert _basenames(_ls_prefixes(paths)) == ["run_b_", "run_c_", "run_a_"]
 
 
 def test_ls_sort_by_non_displayed_field(tmp_path: Any) -> None:
-    """Test --sort-by works for fields not included in --fields (not displayed)."""
-    # Three runs with commands in non-alphabetical order; paths also in non-alphabetical
-    # order so glob/filesystem order cannot accidentally pass the test.
-    entries = [
-        ("run_b_info.json", "cmd_b"),
-        ("run_a_info.json", "cmd_a"),
-        ("run_c_info.json", "cmd_c"),
+    """--sort-by works for fields which are not in --fields (not displayed)."""
+    # commands in non-alphabetical order, and paths not sorted by command either
+    paths = [
+        _write_run(tmp_path / f"run_{letter}_info.json", command=f"cmd_{letter}")
+        for letter in ("b", "a", "c")
     ]
-    for filename, command in entries:
-        (tmp_path / filename).write_text(
-            json.dumps(
-                {
-                    "schema_version": MINIMUM_SCHEMA_VERSION,
-                    "execution_summary": {},
-                    "command": command,
-                }
-            )
-        )
 
-    # paths deliberately in creation order (b, a, c) — not sorted by command
-    paths = [str(tmp_path / filename) for filename, _ in entries]
-    args = argparse.Namespace(
-        paths=paths,
-        colors=False,
-        fields=["prefix"],  # "command" is intentionally NOT in displayed fields
-        eval_filter=None,
-        format="json",
-        func=ls,
-        reverse=False,
-        sort_by=["command"],
+    # "command" is intentionally NOT among the displayed fields
+    prefixes = _ls_prefixes(paths, ["command"], fields=["prefix"])
+
+    assert _basenames(prefixes) == ["run_a_", "run_b_", "run_c_"]
+
+
+def test_ls_sort_by_numeric_field_is_not_lexical(tmp_path: Any) -> None:
+    """Numeric fields sort numerically, not as their rendered strings.
+
+    Sorting happens on the raw values, so 9 sorts before 10 even though the
+    formatted values ("10.000 sec" vs "9.000 sec") would sort the other way.
+    """
+    paths = [
+        _write_run(
+            tmp_path / f"run_{i}_info.json",
+            execution_summary={"wall_clock_time": wall_clock_time},
+        )
+        for i, wall_clock_time in enumerate([10.0, 100.0, 9.0])
+    ]
+
+    prefixes = _ls_prefixes(
+        paths, ["wall_clock_time"], fields=["prefix", "wall_clock_time"]
     )
-    buf = StringIO()
-    with contextlib.redirect_stdout(buf):
-        assert ls(args) == 0
-    rows = json.loads(buf.getvalue().strip())
-    # Output order should match sorted command order: cmd_a, cmd_b, cmd_c
-    # which corresponds to run_a, run_b, run_c prefixes
-    prefixes = [row["prefix"] for row in rows]
-    assert "run_a_" in prefixes[0]
-    assert "run_b_" in prefixes[1]
-    assert "run_c_" in prefixes[2]
+
+    assert _basenames(prefixes) == ["run_2_", "run_0_", "run_1_"]
+
+
+def test_ls_sort_by_version_is_natural(tmp_path: Any) -> None:
+    """Version-like strings sort by their numeric components, not lexically."""
+    paths = [
+        _write_run(tmp_path / f"run_{i}_info.json", schema_version=schema_version)
+        for i, schema_version in enumerate(["0.10.0", "0.2.0", "0.9.0"])
+    ]
+
+    prefixes = _ls_prefixes(paths, ["schema_version"])
+
+    # lexically "0.10.0" < "0.2.0" < "0.9.0", naturally 0.2.0 < 0.9.0 < 0.10.0
+    assert _basenames(prefixes) == ["run_1_", "run_2_", "run_0_"]
+
+
+def test_ls_sort_by_multiple_fields(tmp_path: Any) -> None:
+    """Later --sort-by fields break ties of the earlier ones."""
+    runs = [
+        ("run_0_info.json", "b", 2.0),
+        ("run_1_info.json", "a", 2.0),
+        ("run_2_info.json", "a", 1.0),
+    ]
+    paths = [
+        _write_run(
+            tmp_path / name,
+            command=command,
+            execution_summary={"wall_clock_time": wall_clock_time},
+        )
+        for name, command, wall_clock_time in runs
+    ]
+
+    prefixes = _ls_prefixes(paths, ["command", "wall_clock_time"])
+
+    assert _basenames(prefixes) == ["run_2_", "run_1_", "run_0_"]
+
+
+def test_ls_sort_by_mixed_types_and_missing_values(tmp_path: Any) -> None:
+    """Heterogeneous values must not raise, and missing ones sort last.
+
+    info.json files accumulate across duct versions, so a single field can
+    hold a number in one run, a string in another, a list in a third and be
+    absent from a fourth.
+    """
+    paths = [
+        _write_run(tmp_path / "run_0_info.json", message="text"),
+        _write_run(tmp_path / "run_1_info.json"),  # no message at all
+        _write_run(tmp_path / "run_2_info.json", message=["a", "list"]),
+        _write_run(tmp_path / "run_3_info.json", message=1),
+        _write_run(tmp_path / "run_4_info.json", message=None),
+    ]
+
+    prefixes = _ls_prefixes(paths, ["message"], fields=["prefix", "message"])
+
+    # numbers, then text, then other (json serialized), then missing/None
+    assert _basenames(prefixes)[:3] == ["run_3_", "run_0_", "run_2_"]
+    assert sorted(_basenames(prefixes)[3:]) == ["run_1_", "run_4_"]
+
+
+def test_ls_sort_by_unknown_field_warns(
+    tmp_path: Any, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Sorting by a field no run provides warns and leaves the order alone."""
+    paths = [
+        _write_run(tmp_path / name) for name in ("run_b_info.json", "run_a_info.json")
+    ]
+
+    with caplog.at_level(logging.WARNING, logger="con_duct.ls"):
+        prefixes = _ls_prefixes(paths, ["hostname"])
+
+    assert _basenames(prefixes) == ["run_b_", "run_a_"]
+    assert any("hostname" in record.message for record in caplog.records)
 
 
 @pytest.mark.parametrize("sort_field", LS_FIELD_CHOICES)
 def test_ls_sort_by_each_field(sort_field: str, tmp_path: Any) -> None:
-    """Sorting by every LS_FIELD_CHOICES field must not crash and must produce sorted output."""
-    # Choose 3 values for the sort field, assigned to run1/run2/run3 in the order listed
-    # (val1 to run1, val2 to run2, val3 to run3).  After sorting, the expected output
-    # order must be run2, run1, run3 (smallest to largest).
+    """Every field in LS_FIELD_CHOICES must sort without crashing."""
+    # Values are assigned to run_0/run_1/run_2 in this order and chosen so
+    # that the expected sorted order is always run_1 < run_0 < run_2.
     if sort_field == "prefix":
-        # prefix is derived from the file path by load_duct_runs, not from JSON content.
-        filenames = ["run_b_info.json", "run_a_info.json", "run_c_info.json"]
-        base = {"schema_version": __schema_version__, "execution_summary": {}}
-        for fn in filenames:
-            (tmp_path / fn).write_text(json.dumps(base))
-        paths = [str(tmp_path / fn) for fn in filenames]
-        # sorted prefix order: ...run_a_ < ...run_b_ < ...run_c_
-        expected_fragments = ["run_a_", "run_b_", "run_c_"]
+        # prefix comes from the file path, not from the file content
+        names = ["run_b_info.json", "run_a_info.json", "run_c_info.json"]
+        paths = [_write_run(tmp_path / name) for name in names]
+        expected = ["run_a_", "run_b_", "run_c_"]
     else:
-        # Assign sort values so run2 < run1 < run3.
-        if sort_field == "schema_version":
-            # Must be valid version strings >= MINIMUM_SCHEMA_VERSION.
-            val1, val2, val3 = "0.2.1", "0.2.0", "0.2.2"
+        values: list[Any]
+        if sort_field in VALUE_TRANSFORMATION_MAP:
+            # all transformed fields are numeric -- 10 also proves that they
+            # are not compared as strings ("10" would sort before "2")
+            values = [2, 1, 10]
+        elif sort_field == "schema_version":
+            # has to remain a valid version >= MINIMUM_SCHEMA_VERSION
+            values = ["0.2.1", "0.2.0", "0.2.2"]
         elif sort_field == "gpu":
-            # gpu is a list[dict]; _make_sort_value serialises to JSON string.
-            val1 = [{"name": "gpu_b"}]
-            val2 = [{"name": "gpu_a"}]
-            val3 = [{"name": "gpu_c"}]
+            # gpu is a list[dict] -- not orderable without normalization
+            values = [[{"name": "gpu_b"}], [{"name": "gpu_a"}], [{"name": "gpu_c"}]]
         else:
-            val1, val2, val3 = "sort_b", "sort_a", "sort_c"
+            values = ["sort_b", "sort_a", "sort_c"]
+        paths = [
+            _write_run(tmp_path / f"run_{i}_info.json", **{sort_field: value})
+            for i, value in enumerate(values)
+        ]
+        expected = ["run_1_", "run_0_", "run_2_"]
 
-        def build_run(val: Any) -> Dict[str, Any]:
-            # Use the current schema version so ensure_compliant_schema returns early
-            # and does not overwrite any fields we are setting for the test.
-            data: Dict[str, Any] = {
-                "schema_version": __schema_version__,
-                "execution_summary": {},
-            }
-            if sort_field == "schema_version":
-                data["schema_version"] = val
-            else:
-                # Place at top level; _flatten_dict will expose it for sorting.
-                data[sort_field] = val
-            return data
+    prefixes = _ls_prefixes(paths, [sort_field], fields=["prefix", sort_field])
 
-        filenames = [f"run{i}_info.json" for i in range(1, 4)]
-        for fn, val in zip(filenames, [val1, val2, val3]):
-            (tmp_path / fn).write_text(json.dumps(build_run(val)))
-        paths = [str(tmp_path / fn) for fn in filenames]
-        # sorted: val2(run2) < val1(run1) < val3(run3)
-        expected_fragments = ["run2_", "run1_", "run3_"]
+    assert _basenames(prefixes) == expected, f"sort_by={sort_field!r}"
 
-    args = argparse.Namespace(
-        paths=paths,
-        colors=False,
-        fields=["prefix"],
-        eval_filter=None,
-        format="json",
-        func=ls,
-        reverse=False,
-        sort_by=[sort_field],
-    )
-    buf = StringIO()
-    with contextlib.redirect_stdout(buf):
-        assert ls(args) == 0
-    prefixes = [row["prefix"] for row in json.loads(buf.getvalue().strip())]
-    for i, fragment in enumerate(expected_fragments):
-        assert fragment in prefixes[i], (
-            f"sort_by={sort_field!r}: position {i} expected '{fragment}' in prefix,"
-            f" got '{prefixes[i]}'"
-        )
+
+@pytest.mark.parametrize(
+    "values,expected",
+    [
+        # numbers numerically, including bools and negatives
+        ([3, 1.5, -2, True], [-2, True, 1.5, 3]),
+        # digit runs within text compared as numbers
+        (["run10", "run9", "run2"], ["run2", "run9", "run10"]),
+        (["0.10.0", "0.9.0", "0.2.0"], ["0.2.0", "0.9.0", "0.10.0"]),
+        # numbers before text before other before missing
+        (["b", None, 1, ["a"]], [1, "b", ["a"], None]),
+    ],
+)
+def test_sort_key_orders_values(values: list[Any], expected: list[Any]) -> None:
+    assert sorted(values, key=_sort_key) == expected
+
+
+def test_sort_key_handles_non_serializable_values() -> None:
+    """Values json cannot serialize fall back to their string form."""
+    assert _sort_key(object())[0] == _sort_key([1])[0]
+
+
+def test_natural_chunks_does_not_choke_on_unicode_digits() -> None:
+    """Non-ASCII "digits" which int() cannot parse stay text chunks."""
+    # "\u00b2" (superscript two) is str.isdigit() but not matched by ``\d``
+    assert _natural_chunks("x\u00b2") == ((1, 0, "x\u00b2"),)

--- a/test/test_ls.py
+++ b/test/test_ls.py
@@ -658,19 +658,36 @@ def test_ls_sort_by_mixed_types_and_missing_values(tmp_path: Any) -> None:
     assert sorted(_basenames(prefixes)[3:]) == ["run_1_", "run_4_"]
 
 
-def test_ls_sort_by_unknown_field_warns(
-    tmp_path: Any, caplog: pytest.LogCaptureFixture
+@pytest.mark.parametrize(
+    "fields",
+    [
+        pytest.param({}, id="absent"),
+        # "gpu" is written as null whenever the machine has no GPU
+        pytest.param({"gpu": None}, id="null"),
+    ],
+)
+def test_ls_sort_by_valueless_field_warns(
+    fields: Dict[str, Any], tmp_path: Any, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Sorting by a field no run provides warns and leaves the order alone."""
+    """A field no run has a value for warns and leaves the order alone.
+
+    Both a field absent from every record and one which is null in every
+    record are no-ops for ordering, and both are worth telling the user
+    about.
+    """
     paths = [
-        _write_run(tmp_path / name) for name in ("run_b_info.json", "run_a_info.json")
+        _write_run(tmp_path / name, **fields)
+        for name in ("run_b_info.json", "run_a_info.json")
     ]
 
     with caplog.at_level(logging.WARNING, logger="con_duct.ls"):
-        prefixes = _ls_prefixes(paths, ["hostname"])
+        prefixes = _ls_prefixes(paths, ["gpu"])
 
     assert _basenames(prefixes) == ["run_b_", "run_a_"]
-    assert any("hostname" in record.message for record in caplog.records)
+    assert any(
+        "No run has a value" in record.message and "gpu" in record.message
+        for record in caplog.records
+    )
 
 
 @pytest.mark.parametrize("sort_field", LS_FIELD_CHOICES)

--- a/test/test_ls.py
+++ b/test/test_ls.py
@@ -649,13 +649,21 @@ def test_ls_sort_by_mixed_types_and_missing_values(tmp_path: Any) -> None:
         _write_run(tmp_path / "run_2_info.json", message=["a", "list"]),
         _write_run(tmp_path / "run_3_info.json", message=1),
         _write_run(tmp_path / "run_4_info.json", message=None),
+        _write_run(tmp_path / "run_5_info.json", message=""),
     ]
 
     prefixes = _ls_prefixes(paths, ["message"], fields=["prefix", "message"])
 
-    # numbers, then text, then other (json serialized), then missing/None
-    assert _basenames(prefixes)[:3] == ["run_3_", "run_0_", "run_2_"]
-    assert sorted(_basenames(prefixes)[3:]) == ["run_1_", "run_4_"]
+    # numbers, then text, then other (json serialized), then the valueless
+    # ones -- among which prefix breaks the tie
+    assert _basenames(prefixes) == [
+        "run_3_",
+        "run_0_",
+        "run_2_",
+        "run_1_",
+        "run_4_",
+        "run_5_",
+    ]
 
 
 @pytest.mark.parametrize(
@@ -664,16 +672,19 @@ def test_ls_sort_by_mixed_types_and_missing_values(tmp_path: Any) -> None:
         pytest.param({}, id="absent"),
         # "gpu" is written as null whenever the machine has no GPU
         pytest.param({"gpu": None}, id="null"),
+        # ensure_compliant_schema() backfills newer fields with ""
+        pytest.param({"gpu": ""}, id="empty"),
     ],
 )
 def test_ls_sort_by_valueless_field_warns(
     fields: Dict[str, Any], tmp_path: Any, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """A field no run has a value for warns and leaves the order alone.
+    """A field no run has a value for warns and does not affect the order.
 
-    Both a field absent from every record and one which is null in every
-    record are no-ops for ordering, and both are worth telling the user
-    about.
+    A field absent from every record, null in every record, and backfilled
+    with "" in every record are all no-ops for ordering, and all are worth
+    telling the user about.  Ordering then falls through to the prefix
+    tiebreaker rather than to the arbitrary order of the given paths.
     """
     paths = [
         _write_run(tmp_path / name, **fields)
@@ -683,7 +694,7 @@ def test_ls_sort_by_valueless_field_warns(
     with caplog.at_level(logging.WARNING, logger="con_duct.ls"):
         prefixes = _ls_prefixes(paths, ["gpu"])
 
-    assert _basenames(prefixes) == ["run_b_", "run_a_"]
+    assert _basenames(prefixes) == ["run_a_", "run_b_"]
     assert any(
         "No run has a value" in record.message and "gpu" in record.message
         for record in caplog.records
@@ -750,3 +761,87 @@ def test_natural_chunks_does_not_choke_on_unicode_digits() -> None:
     """Non-ASCII "digits" which int() cannot parse stay text chunks."""
     # "\u00b2" (superscript two) is str.isdigit() but not matched by ``\d``
     assert _natural_chunks("x\u00b2") == ((1, 0, "x\u00b2"),)
+
+
+def test_ls_sort_by_long_digit_run(tmp_path: Any) -> None:
+    """A digit run too long for int() must not blow up the sort.
+
+    Free-form fields hold whatever the user typed, and int() refuses to
+    parse more than sys.get_int_max_str_digits() (4300 by default).
+    """
+    paths = [
+        _write_run(tmp_path / "run_0_info.json", message="9" * 5000),
+        _write_run(tmp_path / "run_1_info.json", message="abc"),
+        _write_run(tmp_path / "run_2_info.json", message="42"),
+    ]
+
+    prefixes = _ls_prefixes(paths, ["message"], fields=["prefix", "message"])
+
+    # 42 is a real number so it sorts first; the oversized run degrades to
+    # text and orders against "abc" as text does
+    assert _basenames(prefixes) == ["run_2_", "run_0_", "run_1_"]
+
+
+def test_ls_sort_by_ties_are_deterministic(tmp_path: Any) -> None:
+    """Runs whose sort field ties come out in prefix order, not input order.
+
+    Without an explicit sort the paths are whatever `glob` returned, which
+    is arbitrary, so equal-keyed runs must not inherit that order.
+    """
+    names = ["run_a_info.json", "run_m_info.json", "run_z_info.json"]
+    paths = [_write_run(tmp_path / name, exit_code=0) for name in names]
+    expected = ["run_a_", "run_m_", "run_z_"]
+
+    assert _basenames(_ls_prefixes(paths, ["exit_code"])) == expected
+    assert _basenames(_ls_prefixes(list(reversed(paths)), ["exit_code"])) == expected
+
+
+def test_ls_sort_by_numeric_non_transformed_field(tmp_path: Any) -> None:
+    """Numeric fields which are displayed as-is also sort numerically."""
+    paths = [
+        _write_run(tmp_path / f"run_{i}_info.json", num_samples=num_samples)
+        for i, num_samples in enumerate([9, 100, 10])
+    ]
+
+    prefixes = _ls_prefixes(paths, ["num_samples"], fields=["prefix", "num_samples"])
+
+    assert _basenames(prefixes) == ["run_0_", "run_2_", "run_1_"]
+
+
+def test_ls_sort_by_applies_after_eval_filter(tmp_path: Any) -> None:
+    """--sort-by orders whatever --eval-filter kept."""
+    paths = [
+        _write_run(tmp_path / f"run_{letter}_info.json", command=f"cmd_{letter}")
+        for letter in ("b", "a", "c")
+    ]
+    args = argparse.Namespace(
+        paths=paths,
+        colors=False,
+        fields=["prefix", "command"],
+        eval_filter="command != 'cmd_b'",
+        format="json",
+        func=ls,
+        reverse=False,
+        sort_by=["command"],
+    )
+    buf = StringIO()
+    with contextlib.redirect_stdout(buf):
+        assert ls(args) == 0
+
+    rows = json.loads(buf.getvalue().strip())
+    assert [row["command"] for row in rows] == ["cmd_a", "cmd_c"]
+
+
+def test_sort_key_treats_nan_as_valueless() -> None:
+    """NaN compares false against everything -- it must not decide order."""
+    assert sorted([3.0, float("nan"), 1.0, 2.0], key=_sort_key)[:3] == [1.0, 2.0, 3.0]
+
+
+@pytest.mark.parametrize("value", [None, ""])
+def test_sort_key_ranks_valueless_last(value: Any) -> None:
+    assert sorted([value, 1, "a"], key=_sort_key) == [1, "a", value]
+
+
+def test_natural_chunks_keeps_oversized_digit_runs_as_text() -> None:
+    digits = "9" * (10**4)
+    assert _natural_chunks(digits) == ((1, 0, digits),)

--- a/test/test_ls.py
+++ b/test/test_ls.py
@@ -567,52 +567,58 @@ def test_ls_sort_by_none_preserves_input_order(tmp_path: Any) -> None:
     assert _basenames(_ls_prefixes(paths)) == ["run_b_", "run_c_", "run_a_"]
 
 
-def test_ls_sort_by_non_displayed_field(tmp_path: Any) -> None:
-    """--sort-by works for fields which are not in --fields (not displayed)."""
-    # commands in non-alphabetical order, and paths not sorted by command either
-    paths = [
-        _write_run(tmp_path / f"run_{letter}_info.json", command=f"cmd_{letter}")
-        for letter in ("b", "a", "c")
-    ]
+@pytest.mark.parametrize(
+    "field,values,expected",
+    [
+        # raw values sort numerically although the rendered "10.000 sec" would
+        # sort before "9.000 sec"
+        pytest.param(
+            "wall_clock_time",
+            [10.0, 100.0, 9.0],
+            ["run_2_", "run_0_", "run_1_"],
+            id="numeric-transformed",
+        ),
+        pytest.param(
+            "num_samples", [9, 100, 10], ["run_0_", "run_2_", "run_1_"], id="numeric"
+        ),
+        # lexically "0.10.0" < "0.2.0" < "0.9.0", naturally 0.2.0 < 0.9.0 < 0.10.0
+        pytest.param(
+            "schema_version",
+            ["0.10.0", "0.2.0", "0.9.0"],
+            ["run_1_", "run_2_", "run_0_"],
+            id="version-natural",
+        ),
+        # "command" is not among the displayed fields (see _ls_prefixes)
+        pytest.param(
+            "command",
+            ["cmd_b", "cmd_a", "cmd_c"],
+            ["run_1_", "run_0_", "run_2_"],
+            id="text-not-displayed",
+        ),
+        # a digit run int() refuses to parse (> sys.get_int_max_str_digits(),
+        # 4300 by default) degrades to text instead of killing the sort
+        pytest.param(
+            "message",
+            ["9" * 5000, "abc", "42"],
+            ["run_2_", "run_0_", "run_1_"],
+            id="oversized-digit-run",
+        ),
+    ],
+)
+def test_ls_sort_by_field(
+    field: str, values: list[Any], expected: list[str], tmp_path: Any
+) -> None:
+    """Runs come out ordered by the raw value of the field, whatever its type."""
+    paths = []
+    for i, value in enumerate(values):
+        record = {field: value}
+        if field == "wall_clock_time":
+            record = {"execution_summary": record}
+        paths.append(_write_run(tmp_path / f"run_{i}_info.json", **record))
 
-    # "command" is intentionally NOT among the displayed fields
-    prefixes = _ls_prefixes(paths, ["command"], fields=["prefix"])
+    prefixes = _ls_prefixes(paths, [field], fields=["prefix", field])
 
-    assert _basenames(prefixes) == ["run_a_", "run_b_", "run_c_"]
-
-
-def test_ls_sort_by_numeric_field_is_not_lexical(tmp_path: Any) -> None:
-    """Numeric fields sort numerically, not as their rendered strings.
-
-    Sorting happens on the raw values, so 9 sorts before 10 even though the
-    formatted values ("10.000 sec" vs "9.000 sec") would sort the other way.
-    """
-    paths = [
-        _write_run(
-            tmp_path / f"run_{i}_info.json",
-            execution_summary={"wall_clock_time": wall_clock_time},
-        )
-        for i, wall_clock_time in enumerate([10.0, 100.0, 9.0])
-    ]
-
-    prefixes = _ls_prefixes(
-        paths, ["wall_clock_time"], fields=["prefix", "wall_clock_time"]
-    )
-
-    assert _basenames(prefixes) == ["run_2_", "run_0_", "run_1_"]
-
-
-def test_ls_sort_by_version_is_natural(tmp_path: Any) -> None:
-    """Version-like strings sort by their numeric components, not lexically."""
-    paths = [
-        _write_run(tmp_path / f"run_{i}_info.json", schema_version=schema_version)
-        for i, schema_version in enumerate(["0.10.0", "0.2.0", "0.9.0"])
-    ]
-
-    prefixes = _ls_prefixes(paths, ["schema_version"])
-
-    # lexically "0.10.0" < "0.2.0" < "0.9.0", naturally 0.2.0 < 0.9.0 < 0.10.0
-    assert _basenames(prefixes) == ["run_1_", "run_2_", "run_0_"]
+    assert _basenames(prefixes) == expected
 
 
 def test_ls_sort_by_multiple_fields(tmp_path: Any) -> None:
@@ -666,6 +672,20 @@ def test_ls_sort_by_mixed_types_and_missing_values(tmp_path: Any) -> None:
     ]
 
 
+def test_ls_sort_by_ties_are_deterministic(tmp_path: Any) -> None:
+    """Runs whose sort field ties come out in prefix order, not input order.
+
+    Without an explicit sort the paths are whatever `glob` returned, which
+    is arbitrary, so equal-keyed runs must not inherit that order.
+    """
+    names = ["run_a_info.json", "run_m_info.json", "run_z_info.json"]
+    paths = [_write_run(tmp_path / name, exit_code=0) for name in names]
+    expected = ["run_a_", "run_m_", "run_z_"]
+
+    assert _basenames(_ls_prefixes(paths, ["exit_code"])) == expected
+    assert _basenames(_ls_prefixes(list(reversed(paths)), ["exit_code"])) == expected
+
+
 @pytest.mark.parametrize(
     "fields",
     [
@@ -681,10 +701,8 @@ def test_ls_sort_by_valueless_field_warns(
 ) -> None:
     """A field no run has a value for warns and does not affect the order.
 
-    A field absent from every record, null in every record, and backfilled
-    with "" in every record are all no-ops for ordering, and all are worth
-    telling the user about.  Ordering then falls through to the prefix
-    tiebreaker rather than to the arbitrary order of the given paths.
+    Ordering then falls through to the prefix tiebreaker rather than to the
+    arbitrary order of the given paths.
     """
     paths = [
         _write_run(tmp_path / name, **fields)
@@ -699,6 +717,30 @@ def test_ls_sort_by_valueless_field_warns(
         "No run has a value" in record.message and "gpu" in record.message
         for record in caplog.records
     )
+
+
+def test_ls_sort_by_applies_after_eval_filter(tmp_path: Any) -> None:
+    """--sort-by orders whatever --eval-filter kept."""
+    paths = [
+        _write_run(tmp_path / f"run_{letter}_info.json", command=f"cmd_{letter}")
+        for letter in ("b", "a", "c")
+    ]
+    args = argparse.Namespace(
+        paths=paths,
+        colors=False,
+        fields=["prefix", "command"],
+        eval_filter="command != 'cmd_b'",
+        format="json",
+        func=ls,
+        reverse=False,
+        sort_by=["command"],
+    )
+    buf = StringIO()
+    with contextlib.redirect_stdout(buf):
+        assert ls(args) == 0
+
+    rows = json.loads(buf.getvalue().strip())
+    assert [row["command"] for row in rows] == ["cmd_a", "cmd_c"]
 
 
 @pytest.mark.parametrize("sort_field", LS_FIELD_CHOICES)
@@ -736,6 +778,9 @@ def test_ls_sort_by_each_field(sort_field: str, tmp_path: Any) -> None:
     assert _basenames(prefixes) == expected, f"sort_by={sort_field!r}"
 
 
+_NAN = float("nan")
+
+
 @pytest.mark.parametrize(
     "values,expected",
     [
@@ -746,6 +791,11 @@ def test_ls_sort_by_each_field(sort_field: str, tmp_path: Any) -> None:
         (["0.10.0", "0.9.0", "0.2.0"], ["0.2.0", "0.9.0", "0.10.0"]),
         # numbers before text before other before missing
         (["b", None, 1, ["a"]], [1, "b", ["a"], None]),
+        # None and "" (what ensure_compliant_schema backfills) are equally
+        # valueless and keep their relative (input) order
+        ([None, 1, "", "a"], [1, "a", None, ""]),
+        # NaN compares false against everything -- it must not decide order
+        ([3.0, _NAN, 1.0, 2.0], [1.0, 2.0, 3.0, _NAN]),
     ],
 )
 def test_sort_key_orders_values(values: list[Any], expected: list[Any]) -> None:
@@ -757,91 +807,16 @@ def test_sort_key_handles_non_serializable_values() -> None:
     assert _sort_key(object())[0] == _sort_key([1])[0]
 
 
-def test_natural_chunks_does_not_choke_on_unicode_digits() -> None:
-    """Non-ASCII "digits" which int() cannot parse stay text chunks."""
-    # "\u00b2" (superscript two) is str.isdigit() but not matched by ``\d``
-    assert _natural_chunks("x\u00b2") == ((1, 0, "x\u00b2"),)
-
-
-def test_ls_sort_by_long_digit_run(tmp_path: Any) -> None:
-    """A digit run too long for int() must not blow up the sort.
-
-    Free-form fields hold whatever the user typed, and int() refuses to
-    parse more than sys.get_int_max_str_digits() (4300 by default).
-    """
-    paths = [
-        _write_run(tmp_path / "run_0_info.json", message="9" * 5000),
-        _write_run(tmp_path / "run_1_info.json", message="abc"),
-        _write_run(tmp_path / "run_2_info.json", message="42"),
-    ]
-
-    prefixes = _ls_prefixes(paths, ["message"], fields=["prefix", "message"])
-
-    # 42 is a real number so it sorts first; the oversized run degrades to
-    # text and orders against "abc" as text does
-    assert _basenames(prefixes) == ["run_2_", "run_0_", "run_1_"]
-
-
-def test_ls_sort_by_ties_are_deterministic(tmp_path: Any) -> None:
-    """Runs whose sort field ties come out in prefix order, not input order.
-
-    Without an explicit sort the paths are whatever `glob` returned, which
-    is arbitrary, so equal-keyed runs must not inherit that order.
-    """
-    names = ["run_a_info.json", "run_m_info.json", "run_z_info.json"]
-    paths = [_write_run(tmp_path / name, exit_code=0) for name in names]
-    expected = ["run_a_", "run_m_", "run_z_"]
-
-    assert _basenames(_ls_prefixes(paths, ["exit_code"])) == expected
-    assert _basenames(_ls_prefixes(list(reversed(paths)), ["exit_code"])) == expected
-
-
-def test_ls_sort_by_numeric_non_transformed_field(tmp_path: Any) -> None:
-    """Numeric fields which are displayed as-is also sort numerically."""
-    paths = [
-        _write_run(tmp_path / f"run_{i}_info.json", num_samples=num_samples)
-        for i, num_samples in enumerate([9, 100, 10])
-    ]
-
-    prefixes = _ls_prefixes(paths, ["num_samples"], fields=["prefix", "num_samples"])
-
-    assert _basenames(prefixes) == ["run_0_", "run_2_", "run_1_"]
-
-
-def test_ls_sort_by_applies_after_eval_filter(tmp_path: Any) -> None:
-    """--sort-by orders whatever --eval-filter kept."""
-    paths = [
-        _write_run(tmp_path / f"run_{letter}_info.json", command=f"cmd_{letter}")
-        for letter in ("b", "a", "c")
-    ]
-    args = argparse.Namespace(
-        paths=paths,
-        colors=False,
-        fields=["prefix", "command"],
-        eval_filter="command != 'cmd_b'",
-        format="json",
-        func=ls,
-        reverse=False,
-        sort_by=["command"],
-    )
-    buf = StringIO()
-    with contextlib.redirect_stdout(buf):
-        assert ls(args) == 0
-
-    rows = json.loads(buf.getvalue().strip())
-    assert [row["command"] for row in rows] == ["cmd_a", "cmd_c"]
-
-
-def test_sort_key_treats_nan_as_valueless() -> None:
-    """NaN compares false against everything -- it must not decide order."""
-    assert sorted([3.0, float("nan"), 1.0, 2.0], key=_sort_key)[:3] == [1.0, 2.0, 3.0]
-
-
-@pytest.mark.parametrize("value", [None, ""])
-def test_sort_key_ranks_valueless_last(value: Any) -> None:
-    assert sorted([value, 1, "a"], key=_sort_key) == [1, "a", value]
-
-
-def test_natural_chunks_keeps_oversized_digit_runs_as_text() -> None:
-    digits = "9" * (10**4)
-    assert _natural_chunks(digits) == ((1, 0, digits),)
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("run10", ((1, 0, "run"), (0, 10, ""))),
+        # "\u00b2" (superscript two) is str.isdigit() but not matched by ``\d``,
+        # and int() cannot parse it
+        ("x\u00b2", ((1, 0, "x\u00b2"),)),
+        # too long for int() -- stays a text chunk
+        ("9" * 10**4, ((1, 0, "9" * 10**4),)),
+    ],
+)
+def test_natural_chunks(text: str, expected: tuple[Any, ...]) -> None:
+    assert _natural_chunks(text) == expected


### PR DESCRIPTION
## Summary
Adds a `--sort-by` command-line option to the `ls` command that allows users to sort results by one or more fields. This enables flexible ordering of duct run records beyond the default input order or simple reverse chronological sorting.

- Closes #433
- Closes #434 (supersedes it: this branch contains all of its commits and addresses its review threads and CI failures)

## Key Changes

- **New CLI argument**: Added `--sort-by` option to `_create_ls_parser()` that accepts one or more field names from `LS_FIELD_CHOICES`
- **Sorting implementation**: 
  - `_sort_run_data()`: Sorts raw run records by specified fields before formatting/display
  - `_sort_key()`: Converts field values to comparable sort keys, handling mixed types (numbers, strings, lists, dicts, None) that may appear in the same field across different runs
  - `_natural_chunks()`: Implements natural/semantic sorting for version strings and numeric components within text (e.g., "run2" < "run10")
- **Type-aware sorting**: Values are ranked by type (numbers → text → other → missing) to prevent TypeErrors when comparing heterogeneous values
- **Non-displayed fields**: Sorting works on any field, including those not in `--fields` (not displayed)
- **Numeric precision**: Numeric fields sort by actual value, not rendered string representation
- **Warning on missing fields**: Logs a warning if a sort field is not provided by any run

## Implementation Details

- Sorting occurs after loading records but before field restriction and formatting, allowing any field to be used as a sort key
- Multiple `--sort-by` fields are applied in order, with later fields breaking ties from earlier ones
- Natural sorting handles both pure numbers and version-like strings with numeric components
- Heterogeneous field values (common in evolving info.json schemas) are handled gracefully by ranking types separately
- Combines with existing `--reverse` flag for descending order

## Tests Added
Comprehensive test coverage including:
- Basic sorting by single and multiple fields
- Natural/semantic version sorting
- Numeric vs. lexical sorting
- Sorting by non-displayed fields
- Mixed types and missing values handling
- Unknown field warnings
- Parametrized tests for all available sort fields

https://claude.ai/code/session_017sEmfsHTr9Ki44PLwzEz8W